### PR TITLE
Subscribe call now async.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonwealth/chain-events",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Listen to various chains for events.",
   "license": "GPL-3.0",
   "files": [

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -50,7 +50,7 @@ export abstract class IEventSubscriber<Api, RawEvent> {
   ) { }
 
   // throws on error
-  public abstract subscribe(cb: (event: RawEvent) => any): void;
+  public abstract subscribe(cb: (event: RawEvent) => any): Promise<void>;
 
   public abstract unsubscribe(): void;
 }

--- a/src/moloch/subscribeFunc.ts
+++ b/src/moloch/subscribeFunc.ts
@@ -158,7 +158,7 @@ export const subscribeEvents: SubscribeFunc<Api, RawEvent, SubscribeOptions> = a
 
   try {
     log.info(`Subscribing to Moloch contract ${chain}...`);
-    subscriber.subscribe(processEventFn);
+    await subscriber.subscribe(processEventFn);
   } catch (e) {
     log.error(`Subscription error: ${e.message}`);
   }

--- a/src/moloch/subscriber.ts
+++ b/src/moloch/subscriber.ts
@@ -20,7 +20,7 @@ export class Subscriber extends IEventSubscriber<Api, RawEvent> {
   /**
    * Initializes subscription to chain and starts emitting events.
    */
-  public subscribe(cb: (event: RawEvent) => any) {
+  public async subscribe(cb: (event: RawEvent) => any): Promise<void> {
     this._listener = (event: RawEvent) => {
       const logStr = `Received ${this._name} event: ${JSON.stringify(event, null, 2)}.`;
       this._verbose ? log.info(logStr) : log.trace(logStr);
@@ -29,7 +29,7 @@ export class Subscriber extends IEventSubscriber<Api, RawEvent> {
     this._api.addListener('*', this._listener);
   }
 
-  public unsubscribe() {
+  public unsubscribe(): void {
     if (this._listener) {
       this._api.removeListener('*', this._listener);
       this._listener = null;

--- a/src/substrate/subscribeFunc.ts
+++ b/src/substrate/subscribeFunc.ts
@@ -162,7 +162,7 @@ export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubscribeOptions
 
   try {
     log.info(`Subscribing to ${chain} endpoint...`);
-    subscriber.subscribe(processBlockFn);
+    await subscriber.subscribe(processBlockFn);
 
     // handle reconnects with poller
     api.on('connected', pollMissedBlocksFn);

--- a/src/substrate/subscriber.ts
+++ b/src/substrate/subscriber.ts
@@ -2,6 +2,7 @@
  * Fetches events from substrate chain in real time.
  */
 import { ApiPromise } from '@polkadot/api';
+import { VoidFn } from '@polkadot/api/types';
 import { Header, RuntimeVersion, Extrinsic } from '@polkadot/types/interfaces';
 
 import { IEventSubscriber } from '../interfaces';
@@ -11,16 +12,16 @@ import { factory, formatFilename } from '../logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export class Subscriber extends IEventSubscriber<ApiPromise, Block> {
-  private _subscription;
+  private _subscription: VoidFn;
   private _versionName: string;
   private _versionNumber: number;
 
   /**
    * Initializes subscription to chain and starts emitting events.
    */
-  public subscribe(cb: (block: Block) => any) {
+  public async subscribe(cb: (block: Block) => any): Promise<void> {
     // wait for version available before we start producing blocks
-    const runtimeVersionP = new Promise((resolve) => {
+    await new Promise((resolve) => {
       this._api.rpc.state.subscribeRuntimeVersion((version: RuntimeVersion) => {
         this._versionNumber = +version.specVersion;
         this._versionName = version.specName.toString();
@@ -28,27 +29,26 @@ export class Subscriber extends IEventSubscriber<ApiPromise, Block> {
         resolve();
       });
     });
-    runtimeVersionP.then(() => {
-      // subscribe to events and pass to block processor
-      this._subscription = this._api.rpc.chain.subscribeNewHeads(async (header: Header) => {
-        const events = await this._api.query.system.events.at(header.hash);
-        const signedBlock = await this._api.rpc.chain.getBlock(header.hash);
-        const extrinsics: Extrinsic[] = signedBlock.block.extrinsics;
-        const block: Block = {
-          header,
-          events,
-          extrinsics,
-          versionNumber: this._versionNumber,
-          versionName: this._versionName,
-        };
-        const logStr = `Fetched Block for ${this._versionName}:${this._versionNumber}: ${+block.header.number}`;
-        this._verbose ? log.info(logStr) : log.trace(logStr);
-        cb(block);
-      });
+
+    // subscribe to events and pass to block processor
+    this._subscription = await this._api.rpc.chain.subscribeNewHeads(async (header: Header) => {
+      const events = await this._api.query.system.events.at(header.hash);
+      const signedBlock = await this._api.rpc.chain.getBlock(header.hash);
+      const extrinsics: Extrinsic[] = signedBlock.block.extrinsics;
+      const block: Block = {
+        header,
+        events,
+        extrinsics,
+        versionNumber: this._versionNumber,
+        versionName: this._versionName,
+      };
+      const logStr = `Fetched Block for ${this._versionName}:${this._versionNumber}: ${+block.header.number}`;
+      this._verbose ? log.info(logStr) : log.trace(logStr);
+      cb(block);
     });
   }
 
-  public unsubscribe() {
+  public unsubscribe(): void {
     if (this._subscription) {
       this._subscription();
       this._subscription = null;

--- a/test/unit/edgeware/subscriber.spec.ts
+++ b/test/unit/edgeware/subscriber.spec.ts
@@ -14,24 +14,24 @@ const events = [
 
 const getApi = () => {
   return constructFakeApi({
-    subscribeNewHeads: (callback) => {
+    subscribeNewHeads: async (callback) => {
       callback({ hash: hashes[0], number: '1' });
       const handle = setTimeout(() => callback({ hash: hashes[1], number: '2' }), 50);
       return () => clearInterval(handle); // unsubscribe
     },
-    'events.at': (hash) => {
+    'events.at': async (hash) => {
       if (hash === hashes[0]) return events[0];
       if (hash === hashes[1]) return events[1];
       assert.fail('events.at called with invalid hash');
     },
-    getBlock: (hash) => {
+    getBlock: async (hash) => {
       return {
         block: {
           extrinsics: [],
         }
       };
     },
-    subscribeRuntimeVersion: (callback) => {
+    subscribeRuntimeVersion: async (callback) => {
       callback({ specVersion: 10, specName: 'edgeware' } as unknown as RuntimeVersion);
     }
   });
@@ -116,11 +116,12 @@ describe('Edgeware Event Subscriber Tests', () => {
           done(err);
         }
       }
-    );
-    setTimeout(() => {
-      subscriber.unsubscribe();
-      setTimeout(() => done(), 50);
-    }, 10);
+    ).then(() => {
+      setTimeout(() => {
+        subscriber.unsubscribe();
+        setTimeout(() => done(), 50);
+      }, 10);
+    });
   });
   // TODO: fail tests
 });

--- a/test/unit/moloch/subscriber.spec.ts
+++ b/test/unit/moloch/subscriber.spec.ts
@@ -28,8 +28,9 @@ describe('Moloch Event Subscriber Tests', () => {
       assert.deepEqual(event, receivedEvent);
       done();
     };
-    subscriber.subscribe(cb);
-    molochApi.emit('*', event);
+    subscriber.subscribe(cb).then(() => {
+      molochApi.emit('*', event);
+    })
   });
 
   it('should no-op on unnecessary unsubscribe', (done) => {
@@ -45,9 +46,10 @@ describe('Moloch Event Subscriber Tests', () => {
     const cb = (receivedEvent: RawEvent) => {
       assert.fail('should not reach callback');
     };
-    subscriber.subscribe(cb);
-    subscriber.unsubscribe();
-    assert.deepEqual(molochApi.listeners('*'), []);
-    done();
+    subscriber.subscribe(cb).then(() => {
+      subscriber.unsubscribe();
+      assert.deepEqual(molochApi.listeners('*'), []);
+      done();
+    })
   });
 });


### PR DESCRIPTION
Fixes #7, cause was improper typing of the polkadot/api `subscribeNewHeads` call (was not resolving the returned promise).