### PR TITLE
Augment NewSession event with validator details

### DIFF
--- a/src/substrate/filters/enricher.ts
+++ b/src/substrate/filters/enricher.ts
@@ -38,25 +38,31 @@ export async function Enrich(
         const [ sessionIndex ] = event.data as unknown as [ SessionIndex ] & Codec
         const validators = await api.derive.staking.validators();
         const currentEra = await api.query.staking.currentEra<Option<EraIndex>>();
-        let exposure : Array<Exposure>
         let active : Array<ValidatorId>
         let waiting : Array<ValidatorId>
-        // erasStakers(EraIndex, AccountId): Exposure -> api.query.staking.erasStakers
-        if (validators && currentEra.isSome) { // if currentEra isn't empty
+        // erasStakers(EraIndex, AccountId): Exposure -> api.query.staking.erasStakers // KUSAMA
+        // stakers(AccountId): Exposure -> api.query.staking.stakers // EDGEWARE
+        const stakersCall = (api.query.staking.stakers)
+          ? api.query.staking.stakers
+          : api.query.staking.erasStakers;
+        const stakersCallArgs = (account) => (api.query.staking.stakers)
+        ? account
+        : [+currentEra, account];
+        let activeExposures : {[key: string]: any} = {}
+        if (validators && currentEra) { // if currentEra isn't empty
           active = validators.validators;
           waiting = validators.nextElected;
           active.forEach(async (validator) => {
-            const tmp_exposure = await api.query.staking.erasStakers(currentEra, validator) as unknown as Exposure & Codec;
-            exposure.push(tmp_exposure)
+            const tmp_exposure = await stakersCall(stakersCallArgs(validator)) as unknown as Exposure & Codec;
+            activeExposures[validator.toString()] = tmp_exposure
           })
         }
         return {
           data: {
             kind,
-            active,
-            waiting,
-            exposure,
-            sessionIndex,
+            activeExposures,
+            waiting:waiting?.map((validator) => validator.toString()),
+            sessionIndex: +sessionIndex,
             currentEra: +currentEra
           }
         }

--- a/src/substrate/types.ts
+++ b/src/substrate/types.ts
@@ -1,7 +1,6 @@
 import {
-  Header, EventRecord, Extrinsic, ValidatorId, Event, IdentityJudgement as SubstrateJudgement, Exposure, SessionIndex
+  Header, EventRecord, Extrinsic, AccountId as _AccountId, Event, IdentityJudgement as SubstrateJudgement, Exposure, SessionIndex
 } from '@polkadot/types/interfaces';
-import { Vec } from '@polkadot/types';
 
 export const EventChains = [
   'edgeware',
@@ -138,8 +137,9 @@ interface IEvent {
  */
 export interface INewSession extends IEvent {
   kind: EventKind.NewSession
-  validators: Array<ValidatorId>;
-  exposure: Array<Exposure>;
+  active: Array<_AccountId>
+  waiting: Array<_AccountId>
+  exposure: Array<Exposure>
   sessionIndex: SessionIndex
   currentEra?: number
 }

--- a/src/substrate/types.ts
+++ b/src/substrate/types.ts
@@ -137,10 +137,9 @@ interface IEvent {
  */
 export interface INewSession extends IEvent {
   kind: EventKind.NewSession
-  active: Array<_AccountId>
-  waiting: Array<_AccountId>
-  exposure: Array<Exposure>
-  sessionIndex: SessionIndex
+  activeExposures: {[key: string]: any}
+  waiting: Array<AccountId>
+  sessionIndex: number
   currentEra?: number
 }
 

--- a/test/unit/edgeware/enricher.spec.ts
+++ b/test/unit/edgeware/enricher.spec.ts
@@ -2,7 +2,7 @@ import chai from 'chai';
 import {
   AccountId, PropIndex, Hash, ReferendumInfoTo239, ReferendumInfo,
   Proposal, TreasuryProposal, Votes, Event, Extrinsic, Registration,
-  RegistrarInfo, ValidatorId, Exposure
+  RegistrarInfo, ValidatorId
 } from '@polkadot/types/interfaces';
 import { DeriveDispatch, DeriveProposalImage } from '@polkadot/api-derive/types';
 import { Vec, bool, Data, TypeRegistry } from '@polkadot/types';
@@ -12,14 +12,50 @@ import { ProposalRecord, VoteRecord } from '@edgeware/node-types';
 import { Enrich } from '../../../src/substrate/filters/enricher';
 import { constructFakeApi, constructOption, constructIdentityJudgement } from './testUtil';
 import { EventKind, IdentityJudgement } from '../../../src/substrate/types';
+import { Session } from 'inspector';
 
 const { assert } = chai;
 
 const blockNumber = 10;
 const api = constructFakeApi({
   validators:async()=>{
-    return await api.createType('Vec<ValidatorId>'); },
+    return await [
+      'EXkCSUQ6Z1hKvGWMNkUDKrTMVHRduQHWc8G6vgo4NccUmhU',
+      'FnWdLnFhRuphztWJJLoNV4zc18dBsjpaAMboPLhLdL7zZp3',
+      'EZ7uBY7ZLohavWAugjTSUVVSABLfad77S6RQf4pDe3cV9q4',
+      'GweeXog8vdnDhjiBCLVvbE4NA4CPTFS3pdFFAFwgZzpUzKu',
+      'DbuPiksDXhFFEWgjsEghUypTJjQKyULiNESYji3Gaose2NV',
+      'Gt6HqWBhdu4Sy1u8ASTbS1qf2Ac5gwdegwr8tWN8saMxPt5',
+      'JKmFAAo9QbR9w3cfSYxk7zdpNEXaN1XbX4NcMU1okAdpwYx'
+    ] },
+  validatorsDerive:async()=>{
+      return await { 
+        validators:[
+        'EXkCSUQ6Z1hKvGWMNkUDKrTMVHRduQHWc8G6vgo4NccUmhU',
+        'FnWdLnFhRuphztWJJLoNV4zc18dBsjpaAMboPLhLdL7zZp3',
+        'EZ7uBY7ZLohavWAugjTSUVVSABLfad77S6RQf4pDe3cV9q4',
+        'GweeXog8vdnDhjiBCLVvbE4NA4CPTFS3pdFFAFwgZzpUzKu',
+        'DbuPiksDXhFFEWgjsEghUypTJjQKyULiNESYji3Gaose2NV',
+        'Gt6HqWBhdu4Sy1u8ASTbS1qf2Ac5gwdegwr8tWN8saMxPt5',
+        'JKmFAAo9QbR9w3cfSYxk7zdpNEXaN1XbX4NcMU1okAdpwYx'
+      ], nextElected:[
+        'JCghFN7mD4ETKzMbvSVmMMPwWutJGk6Bm1yKWk8Z9KhPGeZ',
+        'EDy8hbM5LATNV7P8pPdefEeEs4uptVC1UiVepYNBMhs9Hfj',
+        'Hn8ELsyUL9UgDZpPX6bE464o4sbi7gqgYEKjntK7xuVzGXH',
+        'FkUYJFQt9asnxvgjKt6s1yXjQr3MHDJBTsgfikq4n8qJg4E',
+        'GXTJJh2kQJoS9amET2WmZ82uFkm7HYCScoP9bEDV5JyKsWE',
+        'EDEVriQd4TpEHHyWnLbQHDYjY9avxxkWhNmBou4SHKixgt1',
+        'FhbVbN8VqQLnLkNX76nHAoBBDsC3Jych3k14WbUoJUBbGHr'
+      ]
+    } 
+    },
   currentEra:async()=>12,
+  eraStakers:async()=>{
+    return {"total":"0x0000000000181394a59fde1e31dea1c4","own":"0x0000000000000000002386f262982729","others":[{"who":"mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL","value":"0x0000000000000005a405328cbfd77c63"},{"who":"iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy","value":"0x000000000000001e9e67108749f21184"},{"who":"oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r","value":"0x000000000000000d6d6ad68a401e50e9"},{"who":"ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt","value":"0x000000000000000014d14b817a75054c"},{"who":"nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb","value":"0x0000000000000096c96fada32bab79ca"},{"who":"mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs","value":"0x0000000000000001ae015c352661f300"}]}
+  },
+  stakers:async()=>{
+    return {"total":"0x0000000000181394a59fde1e31dea1c4","own":"0x0000000000000000002386f262982729","others":[{"who":"mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL","value":"0x0000000000000005a405328cbfd77c63"},{"who":"iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy","value":"0x000000000000001e9e67108749f21184"},{"who":"oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r","value":"0x000000000000000d6d6ad68a401e50e9"},{"who":"ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt","value":"0x000000000000000014d14b817a75054c"},{"who":"nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb","value":"0x0000000000000096c96fada32bab79ca"},{"who":"mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs","value":"0x0000000000000001ae015c352661f300"}]}
+  },
   bonded: async (stash) => stash !== 'alice-stash'
     ? constructOption()
     : constructOption('alice' as unknown as AccountId),
@@ -781,20 +817,238 @@ describe('Edgeware Event Enricher Filter Tests', () => {
   /** Session Events */
   it('should enrich new-session event', async () => {
     const kind = EventKind.NewSession;
-    let active : Array<ValidatorId>;
-    let waiting : Array<ValidatorId>;
-    let exposure : Array<Exposure>;
-    const sessionIndex = api.createType('SessionIndex');
+    let activeExposures : {[key: string]: any} = {
+      "DbuPiksDXhFFEWgjsEghUypTJjQKyULiNESYji3Gaose2NV": {
+      "others": [
+      {
+          "value": "0x0000000000000005a405328cbfd77c63",
+          "who": "mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL"
+      },
+      {
+          "value": "0x000000000000001e9e67108749f21184",
+          "who": "iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy"
+      },
+      {
+          "value": "0x000000000000000d6d6ad68a401e50e9",
+          "who": "oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r"
+      },
+      {
+          "value": "0x000000000000000014d14b817a75054c",
+          "who": "ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt"
+      },
+      {
+          "value": "0x0000000000000096c96fada32bab79ca",
+          "who": "nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb"
+      },
+      {
+          "value": "0x0000000000000001ae015c352661f300",
+          "who": "mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs"
+      }
+      ],
+      "own": "0x0000000000000000002386f262982729",
+      "total": "0x0000000000181394a59fde1e31dea1c4"
+  },
+  "EXkCSUQ6Z1hKvGWMNkUDKrTMVHRduQHWc8G6vgo4NccUmhU": {
+      "others": [
+      {
+          "value": "0x0000000000000005a405328cbfd77c63",
+          "who": "mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL"
+      },
+      {
+          "value": "0x000000000000001e9e67108749f21184",
+          "who": "iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy"
+      },
+      {
+          "value": "0x000000000000000d6d6ad68a401e50e9",
+          "who": "oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r"
+      },
+      {
+          "value": "0x000000000000000014d14b817a75054c",
+          "who": "ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt"
+      },
+      {
+          "value": "0x0000000000000096c96fada32bab79ca",
+          "who": "nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb"
+      },
+      {
+          "value": "0x0000000000000001ae015c352661f300",
+          "who": "mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs"
+      }
+      ],
+      "own": "0x0000000000000000002386f262982729",
+      "total": "0x0000000000181394a59fde1e31dea1c4"
+  },
+  "EZ7uBY7ZLohavWAugjTSUVVSABLfad77S6RQf4pDe3cV9q4": {
+      "others": [
+      {
+          "value": "0x0000000000000005a405328cbfd77c63",
+          "who": "mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL"
+      },
+      {
+          "value": "0x000000000000001e9e67108749f21184",
+          "who": "iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy"
+      },
+      {
+          "value": "0x000000000000000d6d6ad68a401e50e9",
+          "who": "oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r"
+      },
+      {
+          "value": "0x000000000000000014d14b817a75054c",
+          "who": "ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt"
+      },
+      {
+          "value": "0x0000000000000096c96fada32bab79ca",
+          "who": "nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb"
+      },
+      {
+          "value": "0x0000000000000001ae015c352661f300",
+          "who": "mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs"
+      }
+      ],
+      "own": "0x0000000000000000002386f262982729",
+      "total": "0x0000000000181394a59fde1e31dea1c4"
+  },
+  "FnWdLnFhRuphztWJJLoNV4zc18dBsjpaAMboPLhLdL7zZp3": {
+      "others": [
+      {
+          "value": "0x0000000000000005a405328cbfd77c63",
+          "who": "mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL"
+      },
+      {
+          "value": "0x000000000000001e9e67108749f21184",
+          "who": "iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy"
+      },
+      {
+          "value": "0x000000000000000d6d6ad68a401e50e9",
+          "who": "oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r"
+      },
+      {
+          "value": "0x000000000000000014d14b817a75054c",
+          "who": "ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt"
+      },
+      {
+          "value": "0x0000000000000096c96fada32bab79ca",
+          "who": "nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb"
+      },
+      {
+          "value": "0x0000000000000001ae015c352661f300",
+          "who": "mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs"
+      }
+      ],
+      "own": "0x0000000000000000002386f262982729",
+      "total": "0x0000000000181394a59fde1e31dea1c4"
+  },
+  "Gt6HqWBhdu4Sy1u8ASTbS1qf2Ac5gwdegwr8tWN8saMxPt5": {
+      "others": [
+      {
+          "value": "0x0000000000000005a405328cbfd77c63",
+          "who": "mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL"
+      },
+      {
+          "value": "0x000000000000001e9e67108749f21184",
+          "who": "iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy"
+      },
+      {
+          "value": "0x000000000000000d6d6ad68a401e50e9",
+          "who": "oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r"
+      },
+      {
+          "value": "0x000000000000000014d14b817a75054c",
+          "who": "ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt"
+      },
+      {
+          "value": "0x0000000000000096c96fada32bab79ca",
+          "who": "nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb"
+      },
+      {
+          "value": "0x0000000000000001ae015c352661f300",
+          "who": "mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs"
+      }
+      ],
+      "own": "0x0000000000000000002386f262982729",
+      "total": "0x0000000000181394a59fde1e31dea1c4"
+  },
+  "GweeXog8vdnDhjiBCLVvbE4NA4CPTFS3pdFFAFwgZzpUzKu": {
+      "others": [
+      {
+          "value": "0x0000000000000005a405328cbfd77c63",
+          "who": "mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL"
+      },
+      {
+          "value": "0x000000000000001e9e67108749f21184",
+          "who": "iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy"
+      },
+      {
+          "value": "0x000000000000000d6d6ad68a401e50e9",
+          "who": "oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r"
+      },
+      {
+          "value": "0x000000000000000014d14b817a75054c",
+          "who": "ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt"
+      },
+      {
+          "value": "0x0000000000000096c96fada32bab79ca",
+          "who": "nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb"
+      },
+      {
+          "value": "0x0000000000000001ae015c352661f300",
+          "who": "mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs"
+      }
+      ],
+      "own": "0x0000000000000000002386f262982729",
+      "total": "0x0000000000181394a59fde1e31dea1c4"
+  },
+  "JKmFAAo9QbR9w3cfSYxk7zdpNEXaN1XbX4NcMU1okAdpwYx": {
+      "others": [
+      {
+          "value": "0x0000000000000005a405328cbfd77c63",
+          "who": "mmhaivFqq2gPP6nMpbVoMtxz1H85FVTfn879X5kforz32CL"
+      },
+      {
+          "value": "0x000000000000001e9e67108749f21184",
+          "who": "iUgUgeVx9WJBea7h8Mm1KGXxurf4UqQfjGVggJ9LfbsMHGy"
+      },
+      {
+          "value": "0x000000000000000d6d6ad68a401e50e9",
+          "who": "oGmCzvaoZgxV5eMbgVnu6KQACC9snRKttAp3V3obHH7Dc9r"
+      },
+      {
+          "value": "0x000000000000000014d14b817a75054c",
+          "who": "ks9is3t3uLnSHByPV6idmGVh74aeeABv9VS7g1hSYQBjZFt"
+      },
+      {
+          "value": "0x0000000000000096c96fada32bab79ca",
+          "who": "nGTjLceLvggC9rZw8mJ3AXSE19o7i7zsLEJkCz3TLNjXfAb"
+      },
+      {
+          "value": "0x0000000000000001ae015c352661f300",
+          "who": "mxZrFA4exCbd3gX77fMYT88L5S2buvcnne4CrQmjT5b3yDs"
+      }
+      ],
+      "own": "0x0000000000000000002386f262982729",
+      "total": "0x0000000000181394a59fde1e31dea1c4"}
+    }
+    let waiting : Array<ValidatorId> = [
+      'JCghFN7mD4ETKzMbvSVmMMPwWutJGk6Bm1yKWk8Z9KhPGeZ',
+      'EDy8hbM5LATNV7P8pPdefEeEs4uptVC1UiVepYNBMhs9Hfj',
+      'Hn8ELsyUL9UgDZpPX6bE464o4sbi7gqgYEKjntK7xuVzGXH',
+      'FkUYJFQt9asnxvgjKt6s1yXjQr3MHDJBTsgfikq4n8qJg4E',
+      'GXTJJh2kQJoS9amET2WmZ82uFkm7HYCScoP9bEDV5JyKsWE',
+      'EDEVriQd4TpEHHyWnLbQHDYjY9avxxkWhNmBou4SHKixgt1',
+      'FhbVbN8VqQLnLkNX76nHAoBBDsC3Jych3k14WbUoJUBbGHr'
+    ] as unknown as Array<ValidatorId>;
+
     const currentEra = 12;
-    const event = constructEvent([ ]);
+    const sessionIndex = 1;
+    const event = constructEvent(['1']);
     const result = await Enrich(api, blockNumber, kind, event);
+    console.log('result', result)
     assert.deepEqual(result, {
       blockNumber,
       data: {
         kind,
-        active,
-        waiting,
-        exposure,
+        activeExposures,
+        waiting:waiting?.map((validator) => validator.toString()),
         sessionIndex,
         currentEra
       }

--- a/test/unit/edgeware/enricher.spec.ts
+++ b/test/unit/edgeware/enricher.spec.ts
@@ -4,7 +4,6 @@ import {
   Proposal, TreasuryProposal, Votes, Event, Extrinsic, Registration,
   RegistrarInfo, ValidatorId, Exposure
 } from '@polkadot/types/interfaces';
-import { Codec } from '@polkadot/types/types';
 import { DeriveDispatch, DeriveProposalImage } from '@polkadot/api-derive/types';
 import { Vec, bool, Data, TypeRegistry } from '@polkadot/types';
 import { ITuple, TypeDef } from '@polkadot/types/types';
@@ -782,7 +781,8 @@ describe('Edgeware Event Enricher Filter Tests', () => {
   /** Session Events */
   it('should enrich new-session event', async () => {
     const kind = EventKind.NewSession;
-    let validators : Array<ValidatorId>;
+    let active : Array<ValidatorId>;
+    let waiting : Array<ValidatorId>;
     let exposure : Array<Exposure>;
     const sessionIndex = api.createType('SessionIndex');
     const currentEra = 12;
@@ -792,7 +792,8 @@ describe('Edgeware Event Enricher Filter Tests', () => {
       blockNumber,
       data: {
         kind,
-        validators,
+        active,
+        waiting,
         exposure,
         sessionIndex,
         currentEra

--- a/test/unit/edgeware/testUtil.ts
+++ b/test/unit/edgeware/testUtil.ts
@@ -99,7 +99,9 @@ export function constructFakeApi(
       },
       staking: {
         bonded: callOverrides['bonded'],
-        currentEra:callOverrides['currentEra']
+        currentEra: callOverrides['currentEra'],
+        eraStakers:callOverrides['eraStakers'],
+        stakers:callOverrides['stakers']
       },
       democracy: {
         referendumInfoOf: callOverrides['referendumInfoOf'],
@@ -132,7 +134,7 @@ export function constructFakeApi(
     },
     derive: {
       staking: {
-        validators: callOverrides['validators'],
+        validators: callOverrides['validatorsDerive'],
       },
       chain: {
         bestNumber: callOverrides['bestNumber'],

--- a/test/unit/edgeware/testUtil.ts
+++ b/test/unit/edgeware/testUtil.ts
@@ -131,6 +131,9 @@ export function constructFakeApi(
       }
     },
     derive: {
+      staking: {
+        validators: callOverrides['validators'],
+      },
       chain: {
         bestNumber: callOverrides['bestNumber'],
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
NewSession event now gives active and waiting validators separately

## Motivation and Context
Update chain events to construct session events for new validator sets
https://github.com/hicommonwealth/substrate/blob/time-travel/frame/session/src/lib.rs#L475
On a new session, enrich the event with the active/waiting validator set.
This gets passed to the event handler below where you will update the DB accordingly.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
