### PR TITLE
Add validator election event and enrich council with members.

### DIFF
--- a/src/substrate/filters/labeler.ts
+++ b/src/substrate/filters/labeler.ts
@@ -173,6 +173,13 @@ export const Label: LabelerFilter = (
         linkUrl: chainId ? `/${chainId}/account/${stash}` : null,
       };
     }
+    case EventKind.StakingElection: {
+      const { era } = data;
+      return {
+        heading: 'Staking Election',
+        label: `A new validator set was elected for era ${era}.`
+      };
+    }
 
     /**
      * Democracy Events

--- a/src/substrate/filters/titler.ts
+++ b/src/substrate/filters/titler.ts
@@ -77,6 +77,12 @@ export const Title: TitlerFilter = (kind: EventKind): IEventTitle => {
         description: 'Your controller account unbonds from a stash account.',
       };
     }
+    case EventKind.StakingElection: {
+      return {
+        title: 'Staking Election',
+        description: 'A new validator set is elected.',
+      }
+    }
 
     /**
      * Democracy Events

--- a/src/substrate/filters/type_parser.ts
+++ b/src/substrate/filters/type_parser.ts
@@ -34,6 +34,7 @@ export function ParseType (
         // NOTE: these are not supported yet on Edgeware, only kusama and edgeware-develop
         case 'Bonded': return EventKind.Bonded;
         case 'Unbonded': return EventKind.Unbonded;
+        case 'StakingElection': return EventKind.StakingElection;
         default: return null;
       }
     case 'democracy':

--- a/src/substrate/types.ts
+++ b/src/substrate/types.ts
@@ -87,6 +87,7 @@ export enum EventKind {
   Reward = 'reward',
   Bonded = 'bonded',
   Unbonded = 'unbonded',
+  StakingElection = 'staking-election',
 
   VoteDelegated = 'vote-delegated',
   DemocracyProposed = 'democracy-proposed',
@@ -222,6 +223,12 @@ export interface IUnbonded extends IEvent {
   controller: AccountId;
 }
 
+export interface IStakingElection extends IEvent {
+  kind: EventKind.StakingElection;
+  era: number;
+  validators: AccountId[];
+}
+
 /**
  * Democracy Events
  */
@@ -348,15 +355,20 @@ export interface ITreasuryRejected extends IEvent {
  */
 export interface IElectionNewTerm extends IEvent {
   kind: EventKind.ElectionNewTerm;
+  round: number;
   newMembers: AccountId[];
+  allMembers: AccountId[];
 }
 
 export interface IElectionEmptyTerm extends IEvent {
   kind: EventKind.ElectionEmptyTerm;
+  round: number;
+  members: AccountId[];
 }
 
 export interface ICandidacySubmitted extends IEvent {
   kind: EventKind.ElectionCandidacySubmitted;
+  round: number;
   candidate: AccountId;
 }
 
@@ -504,6 +516,7 @@ export type IEventData =
   | IReward
   | IBonded
   | IUnbonded
+  | IStakingElection
   | IVoteDelegated
   | IDemocracyProposed
   | IDemocracyTabled

--- a/test/unit/edgeware/enricher.spec.ts
+++ b/test/unit/edgeware/enricher.spec.ts
@@ -25,6 +25,9 @@ const offenceDetails = [
 ];
 const blockNumber = 10;
 const api = constructFakeApi({
+  electionRounds: async () => '10',
+  electionMembers: async () => [ [ 'dave' ], [ 'charlie' ], [ 'eve' ] ],
+  activeEra: async () => '5',
   validators: async () => {
     return {
       'validators': [
@@ -769,6 +772,27 @@ describe('Edgeware Event Enricher Filter Tests', () => {
       }
     });
   });
+  it('should enrich staking-election event', async () => {
+    const kind = EventKind.StakingElection;
+    const event = constructEvent([ ]);
+    const result = await Enrich(api, blockNumber, kind, event);
+    assert.deepEqual(result, {
+      blockNumber,
+      data: {
+        kind,
+        era: 5,
+        validators: [
+          'EXkCSUQ6Z1hKvGWMNkUDKrTMVHRduQHWc8G6vgo4NccUmhU',
+          'FnWdLnFhRuphztWJJLoNV4zc18dBsjpaAMboPLhLdL7zZp3',
+          'EZ7uBY7ZLohavWAugjTSUVVSABLfad77S6RQf4pDe3cV9q4',
+          'GweeXog8vdnDhjiBCLVvbE4NA4CPTFS3pdFFAFwgZzpUzKu',
+          'DbuPiksDXhFFEWgjsEghUypTJjQKyULiNESYji3Gaose2NV',
+          'Gt6HqWBhdu4Sy1u8ASTbS1qf2Ac5gwdegwr8tWN8saMxPt5',
+          'JKmFAAo9QbR9w3cfSYxk7zdpNEXaN1XbX4NcMU1okAdpwYx'
+        ],
+      }
+    });
+  });
 
   /** democracy events */
   it('should enrich vote-delegated event', async () => {
@@ -1026,7 +1050,9 @@ describe('Edgeware Event Enricher Filter Tests', () => {
       blockNumber,
       data: {
         kind,
+        round: 10,
         newMembers: [ 'alice', 'bob' ],
+        allMembers: [ 'dave', 'charlie', 'eve' ],
       }
     });
   });
@@ -1038,6 +1064,8 @@ describe('Edgeware Event Enricher Filter Tests', () => {
       blockNumber,
       data: {
         kind,
+        round: 10,
+        members: [ 'dave', 'charlie', 'eve' ],
       }
     });
   });
@@ -1050,6 +1078,7 @@ describe('Edgeware Event Enricher Filter Tests', () => {
       excludeAddresses: [ 'alice' ],
       data: {
         kind,
+        round: 10,
         candidate: 'alice',
       }
     });

--- a/test/unit/edgeware/processor.spec.ts
+++ b/test/unit/edgeware/processor.spec.ts
@@ -70,6 +70,7 @@ describe('Edgeware Event Processor Tests', () => {
       publicProps: async () => {
         return [ [ ], [ 4, 'hash', 'Alice' ] ];
       },
+      electionRounds: async () => '5',
       referendumInfoOf: async (idx) => {
         if (+idx === 5) {
           return {
@@ -134,6 +135,7 @@ describe('Edgeware Event Processor Tests', () => {
           data: {
             kind: EventKind.ElectionCandidacySubmitted,
             candidate: 'Alice',
+            round: 5,
           },
           blockNumber: 2,
           excludeAddresses: ['Alice'],

--- a/test/unit/edgeware/testUtil.ts
+++ b/test/unit/edgeware/testUtil.ts
@@ -104,12 +104,17 @@ export function constructFakeApi(
         bonded: callOverrides['bonded'],
         currentPoints: callOverrides['currentPoints'],
         currentEra: callOverrides['currentEra'],
-        stakers: callOverrides['stakers']
+        stakers: callOverrides['stakers'],
+        activeEra: callOverrides['activeEra'],
       },
       democracy: {
         referendumInfoOf: callOverrides['referendumInfoOf'],
         publicProps: callOverrides['publicProps'],
         depositOf: callOverrides['depositOf'],
+      },
+      electionsPhragmen: {
+        members: callOverrides['electionMembers'],
+        electionRounds: callOverrides['electionRounds'],
       },
       treasury: {
         proposals: callOverrides['treasuryProposals'],


### PR DESCRIPTION
Changes:
* Adds "StakingElection" event which is fired when validator sets are replaced.
* Enriches NewTerm and EmptyTerm with the full list of members and rounds, and also adds round to CandidacySubmitted.
* Update tests to match changes.