### PR TITLE
Add balance transfer event.

### DIFF
--- a/scripts/listener.ts
+++ b/scripts/listener.ts
@@ -120,6 +120,7 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
       archival,
       startBlock,
       verbose: true,
+      enricherConfig: { balanceTransferThresholdPermill: 1_000 }, // 0.1% of total issuance
     });
   });
 } else if (chainSupportedBy(network, MolochEvents.Types.EventChains)) {

--- a/src/substrate/filters/enricher.ts
+++ b/src/substrate/filters/enricher.ts
@@ -43,8 +43,6 @@ export async function Enrich(
       case EventKind.BalanceTransfer: {
         const [ sender, dest, value ] = event.data as unknown as [ AccountId, AccountId, Balance ] & Codec;
         return {
-          // should not notify sender or recipient
-          excludeAddresses: [ sender.toString(), dest.toString() ],
           data: {
             kind,
             sender: sender.toString(),

--- a/src/substrate/filters/enricher.ts
+++ b/src/substrate/filters/enricher.ts
@@ -43,6 +43,9 @@ export async function Enrich(
     switch (kind) {
       case EventKind.BalanceTransfer: {
         const [ sender, dest, value ] = event.data as unknown as [ AccountId, AccountId, Balance ] & Codec;
+        
+        // TODO: we may want to consider passing a hard threshold rather than recomputing it every
+        //   time, in order to save on queries for chains with a large amount of transfers.
         const totalIssuance = await api.query.balances.totalIssuance();
 
         // only emit to everyone if transfer is 0 or above the configuration threshold

--- a/src/substrate/filters/enricher.ts
+++ b/src/substrate/filters/enricher.ts
@@ -42,23 +42,20 @@ export async function Enrich(
   }> => {
     switch (kind) {
       case EventKind.BalanceTransfer: {
-        const [ transactor, dest, value ] = event.data as unknown as [ AccountId, AccountId, Balance ] & Codec;
+        const [ sender, dest, value ] = event.data as unknown as [ AccountId, AccountId, Balance ] & Codec;
         const totalIssuance = await api.query.balances.totalIssuance();
 
-        // only emit if transfer is 0 or above the configuration threshold
-        const shouldEmit = !config.balanceTransferThresholdPermill
+        // only emit to everyone if transfer is 0 or above the configuration threshold
+        const shouldEmitToAll = !config.balanceTransferThresholdPermill
           || value.muln(1_000_000).divn(config.balanceTransferThresholdPermill).gte(totalIssuance);
-        if (!shouldEmit) return null;
+        const includeAddresses = shouldEmitToAll ? [] : [ sender.toString(), dest.toString() ]; 
 
         return {
-<<<<<<< HEAD
-=======
           // should not notify sender or recipient
-          excludeAddresses: [ transactor.toString(), dest.toString() ],
->>>>>>> parent of 744cd43... Remove enricher config which filtered transfers.
+          includeAddresses,
           data: {
             kind,
-            transactor: transactor.toString(),
+            sender: sender.toString(),
             dest: dest.toString(),
             value: value.toString(),
           }

--- a/src/substrate/filters/labeler.ts
+++ b/src/substrate/filters/labeler.ts
@@ -94,6 +94,13 @@ export const Label: LabelerFilter = (
 ): IEventLabel => {
   const balanceFormatter = (bal) => edgBalanceFormatter(chainId, bal);
   switch (data.kind) {
+    case EventKind.BalanceTransfer: {
+      const { transactor, dest, value } = data;
+      return {
+        heading: 'Balance Transferred',
+        label: `${fmtAddr(transactor)} transferred ${balanceFormatter(value)} to ${fmtAddr(dest)}.`,
+      };
+    }
     /**
      * ImOnline Events
      */

--- a/src/substrate/filters/labeler.ts
+++ b/src/substrate/filters/labeler.ts
@@ -95,10 +95,10 @@ export const Label: LabelerFilter = (
   const balanceFormatter = (bal) => edgBalanceFormatter(chainId, bal);
   switch (data.kind) {
     case EventKind.BalanceTransfer: {
-      const { transactor, dest, value } = data;
+      const { sender, dest, value } = data;
       return {
         heading: 'Balance Transferred',
-        label: `${fmtAddr(transactor)} transferred ${balanceFormatter(value)} to ${fmtAddr(dest)}.`,
+        label: `${fmtAddr(sender)} transferred ${balanceFormatter(value)} to ${fmtAddr(dest)}.`,
       };
     }
     /**

--- a/src/substrate/filters/titler.ts
+++ b/src/substrate/filters/titler.ts
@@ -8,6 +8,12 @@ import { EventKind } from '../types';
  */
 export const Title: TitlerFilter = (kind: EventKind): IEventTitle => {
   switch (kind) {
+    case EventKind.BalanceTransfer: {
+      return {
+        title: 'Balance Transferred',
+        description: 'A balance transfer is performed.',
+      }
+    }
     /**
      * ImOnline Events
      */

--- a/src/substrate/filters/type_parser.ts
+++ b/src/substrate/filters/type_parser.ts
@@ -13,6 +13,12 @@ export function ParseType (
   // TODO: we can unify this with the enricher file: parse out the kind, and then
   //   marshall the rest of the types in the same place. But for now, we can leave as-is.
   switch (section) {
+    case 'balances': {
+      switch (method) {
+        case 'Transfer': return EventKind.BalanceTransfer;
+        default: return null;
+      }
+    }
     case 'imOnline':
       switch (method) {
         case 'AllGood': return EventKind.AllGood;

--- a/src/substrate/processor.ts
+++ b/src/substrate/processor.ts
@@ -15,7 +15,6 @@ const log = factory.getLogger(formatFilename(__filename));
 export class Processor extends IEventProcessor<ApiPromise, Block> {
   constructor(
     protected _api: ApiPromise,
-    private _enricherConfig: EnricherConfig = {},
   ) {
     super(_api);
   }
@@ -48,7 +47,7 @@ export class Processor extends IEventProcessor<ApiPromise, Block> {
         );
       if (kind !== null) {
         try {
-          const result = await Enrich(this._api, blockNumber, kind, data, this._enricherConfig);
+          const result = await Enrich(this._api, blockNumber, kind, data);
           return result;
         } catch (e) {
           log.error(`Event enriching failed for ${kind}`);

--- a/src/substrate/processor.ts
+++ b/src/substrate/processor.ts
@@ -7,12 +7,19 @@ import { Extrinsic, Event } from '@polkadot/types/interfaces';
 import { IEventProcessor, CWEvent } from '../interfaces';
 import { Block, isEvent, IEventData } from './types';
 import { ParseType } from './filters/type_parser';
-import { Enrich } from './filters/enricher';
+import { Enrich, EnricherConfig } from './filters/enricher';
 
 import { factory, formatFilename } from '../logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export class Processor extends IEventProcessor<ApiPromise, Block> {
+  constructor(
+    protected _api: ApiPromise,
+    private _enricherConfig: EnricherConfig = {},
+  ) {
+    super(_api);
+  }
+
   private _lastBlockNumber: number;
   public get lastBlockNumber() { return this._lastBlockNumber; }
 
@@ -41,7 +48,7 @@ export class Processor extends IEventProcessor<ApiPromise, Block> {
         );
       if (kind !== null) {
         try {
-          const result = await Enrich(this._api, blockNumber, kind, data);
+          const result = await Enrich(this._api, blockNumber, kind, data, this._enricherConfig);
           return result;
         } catch (e) {
           log.error(`Event enriching failed for ${kind}`);

--- a/src/substrate/processor.ts
+++ b/src/substrate/processor.ts
@@ -15,6 +15,7 @@ const log = factory.getLogger(formatFilename(__filename));
 export class Processor extends IEventProcessor<ApiPromise, Block> {
   constructor(
     protected _api: ApiPromise,
+    private _enricherConfig: EnricherConfig = {},
   ) {
     super(_api);
   }
@@ -47,7 +48,7 @@ export class Processor extends IEventProcessor<ApiPromise, Block> {
         );
       if (kind !== null) {
         try {
-          const result = await Enrich(this._api, blockNumber, kind, data);
+          const result = await Enrich(this._api, blockNumber, kind, data, this._enricherConfig);
           return result;
         } catch (e) {
           log.error(`Event enriching failed for ${kind}`);

--- a/src/substrate/subscribeFunc.ts
+++ b/src/substrate/subscribeFunc.ts
@@ -11,6 +11,10 @@ import { factory, formatFilename } from '../logging';
 import { EnricherConfig } from './filters/enricher';
 const log = factory.getLogger(formatFilename(__filename));
 
+export interface ISubstrateSubscribeOptions extends ISubscribeOptions<ApiPromise> {
+  enricherConfig?: EnricherConfig;
+}
+
 /**
  * Attempts to open an API connection, retrying if it cannot be opened.
  * @param url websocket endpoing to connect to, including ws[s]:// and port
@@ -45,8 +49,8 @@ export async function createApi(
  * @param discoverReconnectRange A function to determine how long we were offline upon reconnection.
  * @returns An active block subscriber.
  */
-export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubscribeOptions<ApiPromise>> = async (options) => {
-  const { chain, api, handlers, skipCatchup, archival, startBlock, discoverReconnectRange, verbose } = options;
+export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubstrateSubscribeOptions> = async (options) => {
+  const { chain, api, handlers, skipCatchup, archival, startBlock, discoverReconnectRange, verbose, enricherConfig } = options;
   // helper function that sends an event through event handlers
   const handleEventFn = async (event: CWEvent<IEventData>) => {
     let prevResult = null;
@@ -65,7 +69,7 @@ export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubscribeOptions
 
   // helper function that sends a block through the event processor and
   // into the event handlers
-  const processor = new Processor(api);
+  const processor = new Processor(api, enricherConfig || {});
   const processBlockFn = async (block: Block) => {
     // retrieve events from block
     const events: CWEvent<IEventData>[] = await processor.process(block);

--- a/src/substrate/subscribeFunc.ts
+++ b/src/substrate/subscribeFunc.ts
@@ -8,7 +8,12 @@ import { Processor } from './processor';
 import { Block, IEventData } from './types';
 
 import { factory, formatFilename } from '../logging';
+import { EnricherConfig } from './filters/enricher';
 const log = factory.getLogger(formatFilename(__filename));
+
+export interface ISubstrateSubscribeOptions extends ISubscribeOptions<ApiPromise> {
+  enricherConfig?: EnricherConfig;
+}
 
 /**
  * Attempts to open an API connection, retrying if it cannot be opened.
@@ -44,8 +49,8 @@ export async function createApi(
  * @param discoverReconnectRange A function to determine how long we were offline upon reconnection.
  * @returns An active block subscriber.
  */
-export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubscribeOptions<ApiPromise>> = async (options) => {
-  const { chain, api, handlers, skipCatchup, archival, startBlock, discoverReconnectRange, verbose } = options;
+export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubstrateSubscribeOptions> = async (options) => {
+  const { chain, api, handlers, skipCatchup, archival, startBlock, discoverReconnectRange, verbose, enricherConfig } = options;
   // helper function that sends an event through event handlers
   const handleEventFn = async (event: CWEvent<IEventData>) => {
     let prevResult = null;
@@ -64,7 +69,7 @@ export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubscribeOptions
 
   // helper function that sends a block through the event processor and
   // into the event handlers
-  const processor = new Processor(api);
+  const processor = new Processor(api, enricherConfig || {});
   const processBlockFn = async (block: Block) => {
     // retrieve events from block
     const events: CWEvent<IEventData>[] = await processor.process(block);

--- a/src/substrate/subscribeFunc.ts
+++ b/src/substrate/subscribeFunc.ts
@@ -11,10 +11,6 @@ import { factory, formatFilename } from '../logging';
 import { EnricherConfig } from './filters/enricher';
 const log = factory.getLogger(formatFilename(__filename));
 
-export interface ISubstrateSubscribeOptions extends ISubscribeOptions<ApiPromise> {
-  enricherConfig?: EnricherConfig;
-}
-
 /**
  * Attempts to open an API connection, retrying if it cannot be opened.
  * @param url websocket endpoing to connect to, including ws[s]:// and port
@@ -49,8 +45,8 @@ export async function createApi(
  * @param discoverReconnectRange A function to determine how long we were offline upon reconnection.
  * @returns An active block subscriber.
  */
-export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubstrateSubscribeOptions> = async (options) => {
-  const { chain, api, handlers, skipCatchup, archival, startBlock, discoverReconnectRange, verbose, enricherConfig } = options;
+export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubscribeOptions<ApiPromise>> = async (options) => {
+  const { chain, api, handlers, skipCatchup, archival, startBlock, discoverReconnectRange, verbose } = options;
   // helper function that sends an event through event handlers
   const handleEventFn = async (event: CWEvent<IEventData>) => {
     let prevResult = null;
@@ -69,7 +65,7 @@ export const subscribeEvents: SubscribeFunc<ApiPromise, Block, ISubstrateSubscri
 
   // helper function that sends a block through the event processor and
   // into the event handlers
-  const processor = new Processor(api, enricherConfig || {});
+  const processor = new Processor(api);
   const processBlockFn = async (block: Block) => {
     // retrieve events from block
     const events: CWEvent<IEventData>[] = await processor.process(block);

--- a/src/substrate/types.ts
+++ b/src/substrate/types.ts
@@ -117,6 +117,9 @@ export enum EventKind {
   Reward = 'reward',
   Bonded = 'bonded',
   Unbonded = 'unbonded',
+
+  BalanceTransfer = 'balance-transfer',
+
   StakingElection = 'staking-election',
 
   VoteDelegated = 'vote-delegated',
@@ -186,6 +189,13 @@ export enum EventKind {
 
 interface IEvent {
   kind: EventKind;
+}
+
+export interface IBalanceTransfer extends IEvent {
+  kind: EventKind.BalanceTransfer;
+  transactor: AccountId;
+  dest: AccountId;
+  value: BalanceString;
 }
 
 /**
@@ -640,6 +650,7 @@ export type IEventData =
   | IReward
   | IBonded
   | IUnbonded
+  | IBalanceTransfer
   | IStakingElection
   | IVoteDelegated
   | IDemocracyProposed

--- a/src/substrate/types.ts
+++ b/src/substrate/types.ts
@@ -193,7 +193,7 @@ interface IEvent {
 
 export interface IBalanceTransfer extends IEvent {
   kind: EventKind.BalanceTransfer;
-  transactor: AccountId;
+  sender: AccountId;
   dest: AccountId;
   value: BalanceString;
 }

--- a/src/substrate/types.ts
+++ b/src/substrate/types.ts
@@ -193,7 +193,7 @@ interface IEvent {
 
 export interface IBalanceTransfer extends IEvent {
   kind: EventKind.BalanceTransfer;
-  sender: AccountId;
+  transactor: AccountId;
   dest: AccountId;
   value: BalanceString;
 }

--- a/test/unit/edgeware/enricher.spec.ts
+++ b/test/unit/edgeware/enricher.spec.ts
@@ -564,7 +564,6 @@ describe('Edgeware Event Enricher Filter Tests', () => {
     const result = await Enrich(api, blockNumber, kind, event);
     assert.deepEqual(result, {
       blockNumber,
-      excludeAddresses: [ 'alice', 'bob' ],
       data: {
         kind,
         sender: 'alice',

--- a/test/unit/edgeware/enricher.spec.ts
+++ b/test/unit/edgeware/enricher.spec.ts
@@ -5,12 +5,11 @@ import {
   Proposal, TreasuryProposal, Votes, Event, Extrinsic, Registration,
   RegistrarInfo, Bounty, 
 } from '@polkadot/types/interfaces';
-import { DeriveDispatch, DeriveProposalImage, DeriveBounty, DeriveCollectiveProposal, DeriveBounties } from '@polkadot/api-derive/types';
+import { DeriveDispatch, DeriveProposalImage, DeriveBounties } from '@polkadot/api-derive/types';
 import { Vec, bool, Data, TypeRegistry, Option } from '@polkadot/types';
 import { Codec } from '@polkadot/types/types';
 import { ITuple, TypeDef } from '@polkadot/types/types';
 import { stringToHex } from '@polkadot/util';
-import { ProposalRecord, VoteRecord } from '@edgeware/node-types';
 import { ValidatorId, RewardPoint } from '@polkadot/types/interfaces';
 import { OffenceDetails, ReportIdOf } from '@polkadot/types/interfaces/offences';
 import { Enrich } from '../../../src/substrate/filters/enricher';
@@ -26,6 +25,7 @@ const offenceDetails = [
 ];
 const blockNumber = 10;
 const api = constructFakeApi({
+  totalIssuance: async () => new BN(1_000_000),
   electionRounds: async () => '10',
   electionMembers: async () => [ [ 'dave' ], [ 'charlie' ], [ 'eve' ] ],
   activeEra: async () => '5',
@@ -558,6 +558,61 @@ const constructBool = (b: boolean): bool => {
 
 /* eslint-disable: dot-notation */
 describe('Edgeware Event Enricher Filter Tests', () => {
+  it('should enrich balance-transfer event without config', async () => {
+    const kind = EventKind.BalanceTransfer;
+    const event = constructEvent([ 'alice', 'bob', new BN('1001') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
+    const result = await Enrich(api, blockNumber, kind, event);
+    assert.deepEqual(result, {
+      blockNumber,
+      excludeAddresses: [ 'alice', 'bob' ],
+      data: {
+        kind,
+        transactor: 'alice',
+        dest: 'bob',
+        value: '1001',
+      }
+    });
+  });
+  it('should enrich balance-transfer event with threshold 0', async () => {
+    const kind = EventKind.BalanceTransfer;
+    const event = constructEvent([ 'alice', 'bob', new BN('10') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
+    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 0 });
+    assert.deepEqual(result, {
+      blockNumber,
+      excludeAddresses: [ 'alice', 'bob' ],
+      data: {
+        kind,
+        transactor: 'alice',
+        dest: 'bob',
+        value: '10',
+      }
+    });
+  });
+  it('should enrich large balance-transfer event with config', async () => {
+    const kind = EventKind.BalanceTransfer;
+    const event = constructEvent([ 'alice', 'bob', new BN('1001') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
+    
+    // only accept transfers > 1_000
+    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 1_000 });
+    assert.deepEqual(result, {
+      blockNumber,
+      excludeAddresses: [ 'alice', 'bob' ],
+      data: {
+        kind,
+        transactor: 'alice',
+        dest: 'bob',
+        value: '1001',
+      }
+    });
+  });
+  it('should not enrich small balance-transfer event with config', async () => {
+    const kind = EventKind.BalanceTransfer;
+    const event = constructEvent([ 'alice', 'bob', new BN('999') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
+    
+    // only accept transfers > 1_000
+    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 1_000 });
+    assert.isNull(result);
+  });
   it('should enrich new-session event', async () => {
     const kind = EventKind.NewSession;
     let activeExposures: { [key: string]: any } = {

--- a/test/unit/edgeware/enricher.spec.ts
+++ b/test/unit/edgeware/enricher.spec.ts
@@ -558,7 +558,7 @@ const constructBool = (b: boolean): bool => {
 
 /* eslint-disable: dot-notation */
 describe('Edgeware Event Enricher Filter Tests', () => {
-  it('should enrich balance-transfer event without config', async () => {
+  it('should enrich balance-transfer event', async () => {
     const kind = EventKind.BalanceTransfer;
     const event = constructEvent([ 'alice', 'bob', new BN('1001') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
     const result = await Enrich(api, blockNumber, kind, event);
@@ -567,54 +567,15 @@ describe('Edgeware Event Enricher Filter Tests', () => {
       excludeAddresses: [ 'alice', 'bob' ],
       data: {
         kind,
-        transactor: 'alice',
+        sender: 'alice',
         dest: 'bob',
         value: '1001',
       }
     });
-  });
-  it('should enrich balance-transfer event with threshold 0', async () => {
-    const kind = EventKind.BalanceTransfer;
-    const event = constructEvent([ 'alice', 'bob', new BN('10') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
-    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 0 });
-    assert.deepEqual(result, {
-      blockNumber,
-      excludeAddresses: [ 'alice', 'bob' ],
-      data: {
-        kind,
-        transactor: 'alice',
-        dest: 'bob',
-        value: '10',
-      }
-    });
-  });
-  it('should enrich large balance-transfer event with config', async () => {
-    const kind = EventKind.BalanceTransfer;
-    const event = constructEvent([ 'alice', 'bob', new BN('1001') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
-    
-    // only accept transfers > 1_000
-    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 1_000 });
-    assert.deepEqual(result, {
-      blockNumber,
-      excludeAddresses: [ 'alice', 'bob' ],
-      data: {
-        kind,
-        transactor: 'alice',
-        dest: 'bob',
-        value: '1001',
-      }
-    });
-  });
-  it('should not enrich small balance-transfer event with config', async () => {
-    const kind = EventKind.BalanceTransfer;
-    const event = constructEvent([ 'alice', 'bob', new BN('999') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
-    
-    // only accept transfers > 1_000
-    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 1_000 });
-    assert.isNull(result);
   });
   it('should enrich new-session event', async () => {
     const kind = EventKind.NewSession;
+    // TODO: why does this testcase basically do nothing?
     let activeExposures: { [key: string]: any } = {
       "EXkCSUQ6Z1hKvGWMNkUDKrTMVHRduQHWc8G6vgo4NccUmhU": {
         "others": [

--- a/test/unit/edgeware/enricher.spec.ts
+++ b/test/unit/edgeware/enricher.spec.ts
@@ -558,7 +558,7 @@ const constructBool = (b: boolean): bool => {
 
 /* eslint-disable: dot-notation */
 describe('Edgeware Event Enricher Filter Tests', () => {
-  it('should enrich balance-transfer event', async () => {
+  it('should enrich balance-transfer event without config', async () => {
     const kind = EventKind.BalanceTransfer;
     const event = constructEvent([ 'alice', 'bob', new BN('1001') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
     const result = await Enrich(api, blockNumber, kind, event);
@@ -566,15 +566,54 @@ describe('Edgeware Event Enricher Filter Tests', () => {
       blockNumber,
       data: {
         kind,
-        sender: 'alice',
+        transactor: 'alice',
         dest: 'bob',
         value: '1001',
       }
     });
   });
+  it('should enrich balance-transfer event with threshold 0', async () => {
+    const kind = EventKind.BalanceTransfer;
+    const event = constructEvent([ 'alice', 'bob', new BN('10') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
+    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 0 });
+    assert.deepEqual(result, {
+      blockNumber,
+      excludeAddresses: [ 'alice', 'bob' ],
+      data: {
+        kind,
+        transactor: 'alice',
+        dest: 'bob',
+        value: '10',
+      }
+    });
+  });
+  it('should enrich large balance-transfer event with config', async () => {
+    const kind = EventKind.BalanceTransfer;
+    const event = constructEvent([ 'alice', 'bob', new BN('1001') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
+    
+    // only accept transfers > 1_000
+    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 1_000 });
+    assert.deepEqual(result, {
+      blockNumber,
+      excludeAddresses: [ 'alice', 'bob' ],
+      data: {
+        kind,
+        transactor: 'alice',
+        dest: 'bob',
+        value: '1001',
+      }
+    });
+  });
+  it('should not enrich small balance-transfer event with config', async () => {
+    const kind = EventKind.BalanceTransfer;
+    const event = constructEvent([ 'alice', 'bob', new BN('999') ], 'balances', [ 'AccountId', 'AccountId', 'Balance' ]);
+    
+    // only accept transfers > 1_000
+    const result = await Enrich(api, blockNumber, kind, event, { balanceTransferThresholdPermill: 1_000 });
+    assert.isNull(result);
+  });
   it('should enrich new-session event', async () => {
     const kind = EventKind.NewSession;
-    // TODO: why does this testcase basically do nothing?
     let activeExposures: { [key: string]: any } = {
       "EXkCSUQ6Z1hKvGWMNkUDKrTMVHRduQHWc8G6vgo4NccUmhU": {
         "others": [

--- a/test/unit/edgeware/testUtil.ts
+++ b/test/unit/edgeware/testUtil.ts
@@ -159,6 +159,9 @@ export function constructFakeApi(
         blockHash,
         events,
       },
+      balances: {
+        totalIssuance: callOverrides['totalIssuance'],
+      },
       session: {
         nextKeys: callOverrides['nextKeys'],
         currentIndex,


### PR DESCRIPTION
Adds balances.Transfer events, with a configurable threshold in PPM to determine which transactions produce notifications (this sets a precedent for further configuration options to configure what does and doesn't get emit -- potentially useful for spammy events like staking).

Tested via unit tests and manual test on a local chain.

Please bump version before pushing a new NPM package.