### PR TITLE
Refactor ERC20 support.

### DIFF
--- a/scripts/listener.ts
+++ b/scripts/listener.ts
@@ -1,11 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-console */
-import * as yargs from 'yargs';
-import fetch from 'node-fetch';
-import type { RegisteredTypes } from '@polkadot/types/types';
-import { spec as EdgewareSpec } from '@edgeware/node-types';
-import EthDater from 'ethereum-block-by-date';
-
 import {
   chainSupportedBy,
   IEventHandler,
@@ -22,6 +16,12 @@ import { HydraDXSpec } from './specs/hydraDX';
 import { KulupuSpec } from './specs/kulupu';
 import { StafiSpec } from './specs/stafi';
 import { CloverSpec } from './specs/clover';
+
+import * as yargs from 'yargs';
+import fetch from 'node-fetch';
+import type { RegisteredTypes } from '@polkadot/types/types';
+import { spec as EdgewareSpec } from '@edgeware/node-types';
+import EthDater from 'ethereum-block-by-date';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
@@ -257,13 +257,15 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
 } else if (chainSupportedBy(network, Erc20Events.Types.EventChains)) {
   getTokenLists().then(async (tokens) => {
     const tokenAddresses = tokens.map((o) => o.address);
-    const api = await Erc20Events.createApi(url, tokenAddresses);
+    const tokenNames = tokens.map((o) => o.name);
+    const api = await Erc20Events.createApi(url, tokenAddresses, tokenNames);
     Erc20Events.subscribeEvents({
       chain: network,
       api,
       handlers: [new StandaloneEventHandler()],
       skipCatchup,
-      verbose: true,
+      verbose: false,
+      enricherConfig: { balanceTransferThresholdPermill: 500_000 }, // 50% of total supply
     });
   });
 }

--- a/src/chains/erc20/Listener.ts
+++ b/src/chains/erc20/Listener.ts
@@ -10,7 +10,7 @@ import {
   ListenerOptions as Erc20ListenerOptions,
   RawEvent,
   EventChains as erc20Chains,
-  Api,
+  IErc20Contracts,
   EventKind,
 } from './types';
 import { createApi } from './subscribeFunc';
@@ -21,7 +21,7 @@ import { EnricherConfig } from './filters/enricher';
 const log = factory.getLogger(formatFilename(__filename));
 
 export class Listener extends BaseListener<
-  Api,
+  IErc20Contracts,
   never,
   Processor,
   Subscriber,
@@ -57,8 +57,8 @@ export class Listener extends BaseListener<
       this._api = await createApi(
         this._options.url,
         this._options.tokenAddresses,
-        10000,
-        this.options.tokenNames
+        this._options.tokenNames,
+        10000
       );
     } catch (error) {
       log.error(
@@ -101,12 +101,6 @@ export class Listener extends BaseListener<
     }
   }
 
-  public async updateTokenList(tokenAddresses: string[]): Promise<void> {
-    this._options.tokenAddresses = tokenAddresses;
-    await this.init();
-    if (this._subscribed === true) await this.subscribe();
-  }
-
   // override handleEvent to stop the chain from being added to event data
   // since the chain/token name is added to event data in the subscriber.ts
   // (since there are multiple tokens)
@@ -140,6 +134,7 @@ export class Listener extends BaseListener<
 
     // process events in sequence
     for (const e of cwEvents) {
+      // TODO: is this correct?
       e.chain = tokenName as never;
       await this.handleEvent(e as CWEvent);
     }

--- a/src/chains/erc20/Listener.ts
+++ b/src/chains/erc20/Listener.ts
@@ -134,7 +134,7 @@ export class Listener extends BaseListener<
 
     // process events in sequence
     for (const e of cwEvents) {
-      // TODO: is this correct?
+      // TODO: refactor chain/tokenName code in general
       e.chain = tokenName as never;
       await this.handleEvent(e as CWEvent);
     }

--- a/src/chains/erc20/filters/enricher.ts
+++ b/src/chains/erc20/filters/enricher.ts
@@ -1,6 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import BN from 'bn.js';
+
 import { CWEvent } from '../../../interfaces';
-import { EventKind, RawEvent, IEventData, Api } from '../types';
+import { TypedEventFilter } from '../../../contractTypes/commons';
+import { ERC20 } from '../../../contractTypes';
+import { EventKind, RawEvent, IEventData, IErc20Contracts } from '../types';
 
 /**
  * This is an "enricher" function, whose goal is to augment the initial event data
@@ -14,25 +17,42 @@ export interface EnricherConfig {
   // if a balance transfer > (totalIssuance * balanceTransferThresholdPermill / 1_000_000)
   // then emit an event, otherwise do not emit for balance transfer.
   // Set to 0 or undefined to emit for all balance transfers.
-  balanceTransferThreshold?: number;
+  balanceTransferThresholdPermill?: number;
 }
 
+type GetEventArgs<T> = T extends TypedEventFilter<unknown, infer Y> ? Y : never;
+type GetArgType<Name extends keyof ERC20['filters']> = GetEventArgs<
+  ReturnType<ERC20['filters'][Name]>
+>;
+
 export async function Enrich(
-  api: Api,
+  api: IErc20Contracts,
   blockNumber: number,
   kind: EventKind,
   rawData: RawEvent,
   config: EnricherConfig = {}
 ): Promise<CWEvent<IEventData>> {
+  const { totalSupply } = api.tokens.find(
+    ({ contract }) =>
+      contract.address.toLowerCase() === rawData.address.toLowerCase()
+  );
   switch (kind) {
     case EventKind.Approval: {
-      const { owner, spender, value } = rawData.args as any;
+      const {
+        owner,
+        spender,
+        value: valueBigNumber,
+      } = rawData.args as GetArgType<'Approval'>;
       const contractAddress = rawData.address;
+      const value = new BN(valueBigNumber.toString());
 
       // only emit to everyone if approval value is 0 or above the configuration threshold
-      const shouldEmitToAll = config.balanceTransferThreshold
-        ? value.gte(config.balanceTransferThreshold)
-        : false;
+      const shouldEmitToAll =
+        !config.balanceTransferThresholdPermill ||
+        value
+          .muln(1_000_000)
+          .divn(config.balanceTransferThresholdPermill)
+          .gte(totalSupply);
 
       // skip this event if the approval value isn't above the threshold
       if (!shouldEmitToAll) return null;
@@ -47,19 +67,25 @@ export async function Enrich(
           kind,
           owner,
           spender,
-          value,
+          value: value.toString(),
           contractAddress,
         },
       };
     }
     case EventKind.Transfer: {
-      const { from, to, value } = rawData.args as any;
+      const { from, to, value: valueBigNumber } = rawData.args as GetArgType<
+        'Transfer'
+      >;
       const contractAddress = rawData.address;
+      const value = new BN(valueBigNumber.toString());
 
       // only emit to everyone if transfer is 0 or above the configuration threshold
-      const shouldEmitToAll = config.balanceTransferThreshold
-        ? value.gte(config.balanceTransferThreshold)
-        : false;
+      const shouldEmitToAll =
+        !config.balanceTransferThresholdPermill ||
+        value
+          .muln(1_000_000)
+          .divn(config.balanceTransferThresholdPermill)
+          .gte(totalSupply);
 
       // skip this event if the transfer value isn't above the threshold
       if (!shouldEmitToAll) return null;
@@ -74,7 +100,7 @@ export async function Enrich(
           kind,
           from,
           to,
-          value,
+          value: value.toString(),
           contractAddress,
         },
       };

--- a/src/chains/erc20/filters/type_parser.ts
+++ b/src/chains/erc20/filters/type_parser.ts
@@ -15,7 +15,7 @@ export function ParseType(name: string): EventKind | null {
     case 'Transfer':
       return EventKind.Transfer;
     default: {
-      log.warn(`Unknown Erc20 event name: ${name}!`);
+      log.info(`Unknown Erc20 event name: ${name}!`);
       return null;
     }
   }

--- a/src/chains/erc20/processor.ts
+++ b/src/chains/erc20/processor.ts
@@ -6,13 +6,13 @@ import { factory, formatFilename } from '../../logging';
 
 import { ParseType } from './filters/type_parser';
 import { Enrich, EnricherConfig } from './filters/enricher';
-import { IEventData, RawEvent, Api } from './types';
+import { IEventData, RawEvent, IErc20Contracts } from './types';
 
 const log = factory.getLogger(formatFilename(__filename));
 
-export class Processor extends IEventProcessor<Api, RawEvent> {
+export class Processor extends IEventProcessor<IErc20Contracts, RawEvent> {
   constructor(
-    protected _api: Api,
+    protected _api: IErc20Contracts,
     private _enricherConfig: EnricherConfig = {}
   ) {
     super(_api);
@@ -37,7 +37,9 @@ export class Processor extends IEventProcessor<Api, RawEvent> {
       );
       return cwEvent ? [cwEvent] : [];
     } catch (e) {
-      log.error(`Failed to enrich event: ${e.message}`);
+      log.error(
+        `Failed to enrich event ${event.address} (${event.event}): ${e.message}`
+      );
       return [];
     }
   }

--- a/src/chains/erc20/subscribeFunc.ts
+++ b/src/chains/erc20/subscribeFunc.ts
@@ -1,18 +1,21 @@
 import sleep from 'sleep-promise';
+import _ from 'underscore';
+import BN from 'bn.js';
 
 import { createProvider } from '../../eth';
 import { CWEvent, SubscribeFunc, ISubscribeOptions } from '../../interfaces';
 import { factory, formatFilename } from '../../logging';
-import { ERC20__factory as ERC20Factory } from '../../contractTypes';
+import { ERC20__factory as ERC20Factory, ERC20 } from '../../contractTypes';
 
 import { Subscriber } from './subscriber';
 import { Processor } from './processor';
-import { IEventData, RawEvent, Api } from './types';
+import { IEventData, RawEvent, IErc20Contracts } from './types';
 import { EnricherConfig } from './filters/enricher';
 
 const log = factory.getLogger(formatFilename(__filename));
 
-export interface IErc20SubscribeOptions extends ISubscribeOptions<Api> {
+export interface IErc20SubscribeOptions
+  extends ISubscribeOptions<IErc20Contracts> {
   enricherConfig?: EnricherConfig;
 }
 
@@ -28,46 +31,37 @@ export interface IErc20SubscribeOptions extends ISubscribeOptions<Api> {
 export async function createApi(
   ethNetworkUrl: string,
   tokenAddresses: string[],
-  retryTimeMs = 10 * 1000,
-  tokenNames?: string[]
-): Promise<Api> {
+  tokenNames?: string[],
+  retryTimeMs = 10 * 1000
+): Promise<IErc20Contracts> {
   for (let i = 0; i < 3; ++i) {
     try {
       const provider = await createProvider(ethNetworkUrl);
+      log.info(`[erc20]: Connection to ${ethNetworkUrl} successful!`);
 
       const tokenContracts = tokenAddresses.map((o) =>
         ERC20Factory.connect(o, provider)
       );
-      const deployResults = await Promise.all(
-        tokenContracts.map((o, index) =>
-          o
-            .deployed()
-            .then(() => {
-              return {
-                token: o,
-                deployed: true,
-                tokenName: tokenNames ? tokenNames[index] : undefined,
-              };
-            })
-            .catch((err) => {
-              log.error('Failed to find token', err);
-              return {
-                token: o,
-                deployed: false,
-                tokenName: tokenNames ? tokenNames[index] : undefined,
-              };
-            })
-        )
-      );
-
-      const result = deployResults.filter((o) => o.deployed);
-
-      log.info(`[erc20]: Connection to ${ethNetworkUrl} successful!`);
-      return {
-        tokens: result.map((o) => o.token),
-        provider,
-        tokenNames: result.map((o) => o.tokenName),
-      };
+      const deployResults: IErc20Contracts = { provider, tokens: [] };
+      for (const [contract, tokenName] of _.zip(tokenContracts, tokenNames) as [
+        ERC20,
+        string | undefined
+      ][]) {
+        try {
+          await contract.deployed();
+          const totalSupply = new BN((await contract.totalSupply()).toString());
+          deployResults.tokens.push({
+            contract,
+            totalSupply,
+            tokenName,
+          });
+        } catch (err) {
+          log.error(
+            `Error loading token ${contract.address} (${tokenName}): ${err.message}`
+          );
+        }
+      }
+      return deployResults;
     } catch (err) {
       log.error(`Erc20 at ${ethNetworkUrl} failure: ${err.message}`);
       await sleep(retryTimeMs);
@@ -87,7 +81,7 @@ export async function createApi(
  * @returns An active block subscriber.
  */
 export const subscribeEvents: SubscribeFunc<
-  Api,
+  IErc20Contracts,
   RawEvent,
   IErc20SubscribeOptions
 > = async (options) => {
@@ -111,10 +105,7 @@ export const subscribeEvents: SubscribeFunc<
   // helper function that sends a block through the event processor and
   // into the event handlers
   const processor = new Processor(api, enricherConfig || {});
-  const processEventFn = async (
-    event: RawEvent,
-    tokenName?: string
-  ): Promise<void> => {
+  const processEventFn = async (event: RawEvent): Promise<void> => {
     // retrieve events from block
     const cwEvents: CWEvent<IEventData>[] = await processor.process(event);
 

--- a/src/chains/erc20/types.ts
+++ b/src/chains/erc20/types.ts
@@ -1,15 +1,20 @@
 import { Web3Provider } from '@ethersproject/providers';
+import BN from 'bn.js';
 
 import { TypedEvent } from '../../contractTypes/commons';
 import { ERC20 } from '../../contractTypes';
 
 import { EnricherConfig } from './filters/enricher';
 
-// API is imported contracts classes
-interface IErc20Contracts {
-  tokens: ERC20[];
+interface IErc20Contract {
+  contract: ERC20;
+  totalSupply: BN;
+  tokenName?: string;
+}
+
+export interface IErc20Contracts {
+  tokens: IErc20Contract[];
   provider: Web3Provider;
-  tokenNames?: string[];
 }
 
 export interface ListenerOptions {
@@ -19,10 +24,9 @@ export interface ListenerOptions {
   enricherConfig: EnricherConfig;
 }
 
-export type Api = IErc20Contracts;
-
 export const EventChains = ['erc20'] as const;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RawEvent = TypedEvent<any>;
 
 // eslint-disable-next-line no-shadow
@@ -37,13 +41,14 @@ interface IEvent {
 }
 
 type Address = string;
+type Balance = string;
 
 // Erc20 Event Interfaces
 export interface IApproval extends IEvent {
   kind: EventKind.Approval;
   owner: Address;
   spender: Address;
-  value: number;
+  value: Balance;
   contractAddress: Address;
 }
 
@@ -51,25 +56,10 @@ export interface ITransfer extends IEvent {
   kind: EventKind.Transfer;
   from: Address;
   to: Address;
-  value: number;
+  value: Balance;
   contractAddress: Address;
 }
 
 export type IEventData = IApproval | ITransfer;
-// eslint-disable-next-line semi-style
-
-export class Token {
-  public name: string;
-
-  public symbol: string;
-
-  public address: string;
-
-  constructor(name: string, symbol: string, address: string) {
-    this.name = name;
-    this.symbol = symbol;
-    this.address = address;
-  }
-}
 
 export const EventKinds: EventKind[] = Object.values(EventKind);

--- a/test/unit/aave/listener.spec.ts
+++ b/test/unit/aave/listener.spec.ts
@@ -10,7 +10,7 @@ import {
   Listener,
 } from '../../../src/chains/aave';
 import { networkUrls, EventSupportingChainT, contracts } from '../../../src';
-import { testHandler } from '../../util';
+import { TestHandler } from '../../util';
 
 dotenv.config();
 
@@ -48,12 +48,12 @@ describe('Aave listener class tests', () => {
   });
 
   it('should add a handler', async () => {
-    listener.eventHandlers.testHandler = {
-      handler: new testHandler(listener._verbose, handlerEmitter),
+    listener.eventHandlers.TestHandler = {
+      handler: new TestHandler(listener._verbose, handlerEmitter),
       excludedEvents: [],
     };
 
-    assert(listener.eventHandlers.testHandler.handler instanceof testHandler);
+    assert(listener.eventHandlers.TestHandler.handler instanceof TestHandler);
   });
 
   it('should subscribe the listener to the specified chain', async () => {
@@ -64,7 +64,7 @@ describe('Aave listener class tests', () => {
   it('should verify that the handler handled an event successfully', (done) => {
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
       if (counter == 1) {
         clearTimeout(timeoutHandler);
@@ -88,10 +88,10 @@ describe('Aave listener class tests', () => {
   xit('should update the contract address');
 
   xit('should verify that the handler handled an event successfully after changing contract address', (done) => {
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    listener.eventHandlers.TestHandler.handler.counter = 0;
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
       if (counter == 1) done();
     };
@@ -102,10 +102,10 @@ describe('Aave listener class tests', () => {
 
   xit('should verify that the handler handled an event successfully after changing urls', () => {
     assert(
-      listener.eventHandlers.testHandler.handler.counter >= 1,
+      listener.eventHandlers.TestHandler.handler.counter >= 1,
       'Handler was not triggered/used'
     );
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    listener.eventHandlers.TestHandler.handler.counter = 0;
   });
 
   it('should unsubscribe from the chain', async () => {

--- a/test/unit/compound/listener.spec.ts
+++ b/test/unit/compound/listener.spec.ts
@@ -10,7 +10,7 @@ import {
   Listener,
 } from '../../../src/chains/compound';
 import { networkUrls, EventSupportingChainT, contracts } from '../../../src';
-import { testHandler } from '../../util';
+import { TestHandler } from '../../util';
 
 dotenv.config();
 
@@ -48,12 +48,12 @@ describe('Compound listener class tests', () => {
   });
 
   it('should add a handler', async () => {
-    listener.eventHandlers.testHandler = {
-      handler: new testHandler(listener._verbose, handlerEmitter),
+    listener.eventHandlers.TestHandler = {
+      handler: new TestHandler(listener._verbose, handlerEmitter),
       excludedEvents: [],
     };
 
-    assert(listener.eventHandlers.testHandler.handler instanceof testHandler);
+    assert(listener.eventHandlers.TestHandler.handler instanceof TestHandler);
   });
 
   it('should subscribe the listener to the specified chain', async () => {
@@ -64,7 +64,7 @@ describe('Compound listener class tests', () => {
   it('should verify that the handler handled an event successfully', (done) => {
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
       if (counter == 1) {
         clearTimeout(timeoutHandler);
@@ -88,10 +88,10 @@ describe('Compound listener class tests', () => {
   xit('should update the contract address');
 
   xit('should verify that the handler handled an event successfully after changing contract address', (done) => {
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    listener.eventHandlers.TestHandler.handler.counter = 0;
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
       if (counter == 1) done();
     };
@@ -102,10 +102,10 @@ describe('Compound listener class tests', () => {
 
   xit('should verify that the handler handled an event successfully after changing urls', () => {
     assert(
-      listener.eventHandlers.testHandler.handler.counter >= 1,
+      listener.eventHandlers.TestHandler.handler.counter >= 1,
       'Handler was not triggered/used'
     );
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    listener.eventHandlers.TestHandler.handler.counter = 0;
   });
 
   it('should unsubscribe from the chain', async () => {

--- a/test/unit/erc20/listener.spec.ts
+++ b/test/unit/erc20/listener.spec.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 
 import { Processor, Subscriber, Listener } from '../../../src/chains/erc20';
 import { networkUrls, EventSupportingChainT } from '../../../src';
-import { testHandler } from '../../util';
+import { TestHandler } from '../../util';
 
 dotenv.config();
 
@@ -22,12 +22,13 @@ describe('Erc20 listener class tests', () => {
 
   it('should throw if the chain is not an Aave based contract', () => {
     try {
+      // eslint-disable-next-line no-new
       new Listener(
         'randomChain' as EventSupportingChainT,
         tokenAddresses,
         networkUrls.erc20,
         tokenNames,
-        false
+        {}
       );
     } catch (error) {
       assert(String(error).includes('randomChain'));
@@ -40,7 +41,7 @@ describe('Erc20 listener class tests', () => {
       tokenAddresses,
       networkUrls.erc20,
       tokenNames,
-      false
+      {}
     );
     assert.equal(listener.chain, 'erc20');
     assert.deepEqual(listener.options, {
@@ -59,12 +60,12 @@ describe('Erc20 listener class tests', () => {
   });
 
   it('should add a handler', async () => {
-    listener.eventHandlers.testHandler = {
-      handler: new testHandler(listener._verbose, handlerEmitter),
+    listener.eventHandlers.TestHandler = {
+      handler: new TestHandler(listener._verbose, handlerEmitter),
       excludedEvents: [],
     };
 
-    assert(listener.eventHandlers.testHandler.handler instanceof testHandler);
+    assert(listener.eventHandlers.TestHandler.handler instanceof TestHandler);
   });
 
   it('should subscribe the listener to the specified erc20 tokens', async () => {
@@ -75,9 +76,9 @@ describe('Erc20 listener class tests', () => {
   it('should verify that the handler handled an event successfully', (done) => {
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
-      if (counter == 1) {
+      if (counter === 1) {
         done();
       }
     };
@@ -87,24 +88,25 @@ describe('Erc20 listener class tests', () => {
   xit('should update a contract address');
 
   xit('should verify that the handler handled an event successfully after changing contract address', (done) => {
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    listener.eventHandlers.TestHandler.handler.counter = 0;
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
-      if (counter == 1) done();
+      if (counter === 1) done();
     };
     handlerEmitter.on('eventHandled', verifyHandler);
   }).timeout(20000);
 
-  xit('should update the url the listener should connect to', async () => {});
+  xit('should update the url the listener should connect to', async () =>
+    undefined);
 
   xit('should verify that the handler handled an event successfully after changing urls', () => {
     assert(
-      listener.eventHandlers.testHandler.handler.counter >= 1,
+      listener.eventHandlers.TestHandler.handler.counter >= 1,
       'Handler was not triggered/used'
     );
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    listener.eventHandlers.TestHandler.handler.counter = 0;
   });
 
   it('should unsubscribe from the chain', async () => {

--- a/test/unit/moloch/listener.spec.ts
+++ b/test/unit/moloch/listener.spec.ts
@@ -10,7 +10,7 @@ import {
   Listener,
 } from '../../../src/chains/moloch';
 import { networkUrls, EventSupportingChainT, contracts } from '../../../src';
-import { testHandler } from '../../util';
+import { TestHandler } from '../../util';
 
 dotenv.config();
 
@@ -49,12 +49,12 @@ describe('Moloch listener class tests', () => {
   });
 
   it('should add a handler', async () => {
-    listener.eventHandlers.testHandler = {
-      handler: new testHandler(listener._verbose, handlerEmitter),
+    listener.eventHandlers.TestHandler = {
+      handler: new TestHandler(listener._verbose, handlerEmitter),
       excludedEvents: [],
     };
 
-    assert(listener.eventHandlers.testHandler.handler instanceof testHandler);
+    assert(listener.eventHandlers.TestHandler.handler instanceof TestHandler);
   });
 
   it('should subscribe the listener to the specified chain', async () => {
@@ -65,7 +65,7 @@ describe('Moloch listener class tests', () => {
   it('should verify that the handler handled an event successfully', (done) => {
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
       if (counter == 1) {
         clearTimeout(timeoutHandler);
@@ -91,10 +91,10 @@ describe('Moloch listener class tests', () => {
   xit('should update the contract version');
 
   xit('should verify that the handler handled an event successfully after changing contract versions', (done) => {
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    listener.eventHandlers.TestHandler.handler.counter = 0;
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
       if (counter == 1) done();
     };
@@ -105,10 +105,10 @@ describe('Moloch listener class tests', () => {
 
   xit('should verify that the handler handled an event successfully after changing urls', () => {
     assert(
-      listener.eventHandlers.testHandler.handler.counter >= 1,
+      listener.eventHandlers.TestHandler.handler.counter >= 1,
       'Handler was not triggered/used'
     );
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    listener.eventHandlers.TestHandler.handler.counter = 0;
   });
 
   it('should unsubscribe from the chain', async () => {

--- a/test/unit/substrate/listener.spec.ts
+++ b/test/unit/substrate/listener.spec.ts
@@ -11,7 +11,7 @@ import {
   Listener,
 } from '../../../src/chains/substrate';
 import { networkUrls, EventSupportingChainT } from '../../../src';
-import { testHandler } from '../../util';
+import { TestHandler } from '../../util';
 
 const { assert } = chai;
 
@@ -64,12 +64,12 @@ describe('Substrate listener class tests', () => {
   });
 
   it('should add a handler', async () => {
-    listener.eventHandlers.testHandler = {
-      handler: new testHandler(listener._verbose, handlerEmitter),
+    listener.eventHandlers.TestHandler = {
+      handler: new TestHandler(listener._verbose, handlerEmitter),
       excludedEvents: [],
     };
 
-    assert(listener.eventHandlers.testHandler.handler instanceof testHandler);
+    assert(listener.eventHandlers.TestHandler.handler instanceof TestHandler);
   });
 
   it('should subscribe the listener to the specified chain', async () => {
@@ -80,7 +80,7 @@ describe('Substrate listener class tests', () => {
   it('should verify that the handler handled an event successfully', (done) => {
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
       if (counter == 1) {
         clearTimeout(timeoutHandler);
@@ -109,7 +109,7 @@ describe('Substrate listener class tests', () => {
   it('should verify that the handler handled an event successfully after changing specs', (done) => {
     let counter = 0;
     const verifyHandler = () => {
-      assert(listener.eventHandlers.testHandler.handler.counter >= 1);
+      assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
       ++counter;
       if (counter == 1) {
         clearTimeout(timeoutHandler);
@@ -133,8 +133,8 @@ describe('Substrate listener class tests', () => {
   xit('should update the url to the listener should connect to', async () => {});
 
   xit('should verify that the handler handled an event successfully after changing urls', () => {
-    assert(listener.eventHandlers.testHandler.handler.counter >= 1);
-    listener.eventHandlers.testHandler.handler.counter = 0;
+    assert(listener.eventHandlers.TestHandler.handler.counter >= 1);
+    listener.eventHandlers.TestHandler.handler.counter = 0;
   });
 
   it('should unsubscribe from the chain', async () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -7,7 +7,7 @@ import {
   ChainEventKinds,
 } from '../src';
 
-export class testHandler implements IEventHandler {
+export class TestHandler implements IEventHandler {
   private counter = 0;
 
   constructor(


### PR DESCRIPTION
Open questions:
- How is tokenName used? The `e.chain = tokenName as never` bit is probably going to break, and also gets overwritten elsewhere.
- I'm also a bit unclear on the flow, of `subscribeEvents` vs the Listener class. Ideally the two would be unified but switched depending on whether it's a local or queue subscription. This is related to my first open question.

PR works based on running the listener manually (currently set to 50% token supply threshold, need to verify this is explicitly respected though).