### PR TITLE
Tim.alchemy

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "integration-test": "cd eth && hardhat test ../test/integration/*.spec.ts",
     "lint": "eslint src/ test/",
     "listen": "ts-node -T ./scripts/listener.ts",
+    "listenV2": "ts-node -T ./scripts/listenerV2.ts",
     "listen-archival": "ts-node -T ./scripts/listener.ts -n edgeware-local -a true",
     "scrape": "ts-node -T ./scripts/scraper.ts",
     "ganache": "ganache-cli -m \"Alice\" -p 9545 -l 800000000 --allowUnlimitedContractSize",

--- a/scripts/listener.ts
+++ b/scripts/listener.ts
@@ -1,5 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-console */
+
+import * as yargs from 'yargs';
+import fetch from 'node-fetch';
+import EthDater from 'ethereum-block-by-date';
+
 import {
   chainSupportedBy,
   IEventHandler,
@@ -13,10 +18,6 @@ import {
 } from '../src/index';
 
 import { contracts, networkSpecs, networkUrls } from './listenerUtils';
-
-import * as yargs from 'yargs';
-import fetch from 'node-fetch';
-import EthDater from 'ethereum-block-by-date';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();

--- a/scripts/listener.ts
+++ b/scripts/listener.ts
@@ -1,10 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-console */
 
-import * as yargs from 'yargs';
-import fetch from 'node-fetch';
-import EthDater from 'ethereum-block-by-date';
-
 import {
   chainSupportedBy,
   IEventHandler,
@@ -18,6 +14,10 @@ import {
 } from '../src/index';
 
 import { contracts, networkSpecs, networkUrls } from './listenerUtils';
+
+import * as yargs from 'yargs';
+import fetch from 'node-fetch';
+import EthDater from 'ethereum-block-by-date';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
@@ -162,10 +162,10 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
   CompoundEvents.createApi(url, contract).then(async (api) => {
     const fetcher = new CompoundEvents.StorageFetcher(api);
     try {
-      const fetched = await fetcher.fetch(
-        { startBlock: 13353227, maxResults: 1 },
-        true
-      );
+      const fetched = await fetcher.fetch({
+        startBlock: 13353227,
+        maxResults: 1,
+      });
       // const fetched = await fetcher.fetchOne('2');
       console.log(fetched.map((f) => f.data));
     } catch (err) {
@@ -185,10 +185,10 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
   AaveEvents.createApi(url, contract).then(async (api) => {
     const fetcher = new AaveEvents.StorageFetcher(api);
     try {
-      const fetched = await fetcher.fetch(
-        { startBlock: 13353227, maxResults: 1 },
-        true
-      );
+      const fetched = await fetcher.fetch({
+        startBlock: 13353227,
+        maxResults: 1,
+      });
       // const fetched = await fetcher.fetchOne('10');
       console.log(fetched.sort((a, b) => a.blockNumber - b.blockNumber));
     } catch (err) {

--- a/scripts/listenerUtils.ts
+++ b/scripts/listenerUtils.ts
@@ -1,10 +1,10 @@
+import type { RegisteredTypes } from '@polkadot/types/types';
+import { spec as EdgewareSpec } from '@edgeware/node-types';
+
 import { HydraDXSpec } from './specs/hydraDX';
 import { KulupuSpec } from './specs/kulupu';
 import { StafiSpec } from './specs/stafi';
 import { CloverSpec } from './specs/clover';
-
-import type { RegisteredTypes } from '@polkadot/types/types';
-import { spec as EdgewareSpec } from '@edgeware/node-types';
 
 export const networkUrls = {
   clover: 'wss://api.clover.finance',
@@ -17,20 +17,20 @@ export const networkUrls = {
   kulupu: 'ws://rpc.kulupu.corepaper.org/ws',
   stafi: 'wss://scan-rpc.stafi.io/ws',
 
-  moloch: 'wss://mainnet.infura.io/ws',
+  moloch: 'wss://eth-mainnet.alchemyapi.io/v2/',
   'moloch-local': 'ws://127.0.0.1:9545',
 
-  marlin: 'wss://mainnet.infura.io/ws',
+  marlin: 'wss://eth-mainnet.alchemyapi.io/v2/',
   'marlin-local': 'ws://127.0.0.1:9545',
-  uniswap: 'wss://mainnet.infura.io/ws',
-  tribe: 'wss://mainnet.infura.io/ws',
+  uniswap: 'wss://eth-mainnet.alchemyapi.io/v2/',
+  tribe: 'wss://eth-mainnet.alchemyapi.io/v2/',
 
-  aave: 'wss://mainnet.infura.io/ws',
+  aave: 'wss://eth-mainnet.alchemyapi.io/v2/',
   'aave-local': 'ws://127.0.0.1:9545',
-  'dydx-ropsten': 'wss://ropsten.infura.io/ws',
-  dydx: 'wss://mainnet.infura.io/ws',
+  'dydx-ropsten': 'wss://eth-ropsten.alchemyapi.io/v2/',
+  dydx: 'wss://eth-mainnet.alchemyapi.io/v2/',
 
-  erc20: 'wss://mainnet.infura.io/ws',
+  erc20: 'wss://eth-mainnet.alchemyapi.io/v2/',
 } as const;
 
 export const networkSpecs: { [chain: string]: RegisteredTypes } = {

--- a/scripts/listenerUtils.ts
+++ b/scripts/listenerUtils.ts
@@ -1,10 +1,10 @@
-import type { RegisteredTypes } from '@polkadot/types/types';
-import { spec as EdgewareSpec } from '@edgeware/node-types';
-
 import { HydraDXSpec } from './specs/hydraDX';
 import { KulupuSpec } from './specs/kulupu';
 import { StafiSpec } from './specs/stafi';
 import { CloverSpec } from './specs/clover';
+
+import { spec as EdgewareSpec } from '@edgeware/node-types';
+import type { RegisteredTypes } from '@polkadot/types/types';
 
 export const networkUrls = {
   clover: 'wss://api.clover.finance',
@@ -17,20 +17,20 @@ export const networkUrls = {
   kulupu: 'ws://rpc.kulupu.corepaper.org/ws',
   stafi: 'wss://scan-rpc.stafi.io/ws',
 
-  moloch: 'wss://eth-mainnet.alchemyapi.io/v2/',
+  moloch: 'wss://mainnet.infura.io/ws',
   'moloch-local': 'ws://127.0.0.1:9545',
 
-  marlin: 'wss://eth-mainnet.alchemyapi.io/v2/',
+  marlin: 'wss://mainnet.infura.io/ws',
   'marlin-local': 'ws://127.0.0.1:9545',
-  uniswap: 'wss://eth-mainnet.alchemyapi.io/v2/',
-  tribe: 'wss://eth-mainnet.alchemyapi.io/v2/',
+  uniswap: 'wss://mainnet.infura.io/ws',
+  tribe: 'wss://mainnet.infura.io/ws',
 
-  aave: 'wss://eth-mainnet.alchemyapi.io/v2/',
+  aave: 'wss://mainnet.infura.io/ws',
   'aave-local': 'ws://127.0.0.1:9545',
-  'dydx-ropsten': 'wss://eth-ropsten.alchemyapi.io/v2/',
-  dydx: 'wss://eth-mainnet.alchemyapi.io/v2/',
+  'dydx-ropsten': 'wss://ropsten.infura.io/ws',
+  dydx: 'wss://mainnet.infura.io/ws',
 
-  erc20: 'wss://eth-mainnet.alchemyapi.io/v2/',
+  erc20: 'wss://mainnet.infura.io/ws',
 } as const;
 
 export const networkSpecs: { [chain: string]: RegisteredTypes } = {

--- a/scripts/listenerV2.ts
+++ b/scripts/listenerV2.ts
@@ -1,0 +1,60 @@
+import * as yargs from 'yargs';
+
+import { createListener, EventSupportingChains, LoggingHandler } from '../src';
+
+const { argv } = yargs.options({
+  network: {
+    alias: 'n',
+    choices: EventSupportingChains,
+    demandOption: true,
+    description: 'chain to listen on',
+  },
+  url: {
+    alias: 'u',
+    type: 'string',
+    description: 'node url',
+  },
+  contractAddress: {
+    alias: 'c',
+    type: 'string',
+    description: 'eth contract address',
+  },
+  tokenName: {
+    alias: 'a',
+    type: 'string',
+    description:
+      'Name of the token if network is erc20 and contractAddress is a erc20 token address',
+  },
+});
+
+async function main(): Promise<any> {
+  let listener;
+  try {
+    listener = await createListener(argv.network, {
+      url: argv.url,
+      address: argv.contractAddress,
+      tokenAddresses: [argv.contractAddress],
+      tokenNames: [argv.tokenName],
+      verbose: false,
+      enricherConfig: {
+        balanceTransferThreshold: 500_000,
+      },
+    });
+
+    listener.eventHandlers.logger = {
+      handler: new LoggingHandler(),
+      excludedEvents: [],
+    };
+
+    await listener.subscribe();
+  } catch (e) {
+    console.log(e);
+  }
+
+  return listener;
+}
+
+main().then((listener) => {
+  const temp = listener;
+  console.log('Subscribed...');
+});

--- a/src/eth.ts
+++ b/src/eth.ts
@@ -1,6 +1,5 @@
 import { providers } from 'ethers';
 import Web3 from 'web3';
-import fetch from 'node-fetch';
 
 import { factory, formatFilename } from './logging';
 
@@ -9,59 +8,44 @@ const log = factory.getLogger(formatFilename(__filename));
 export async function createProvider(
   ethNetworkUrl: string
 ): Promise<providers.Web3Provider> {
-  if (!ethNetworkUrl.includes('alchemy'))
-    throw Error('Must use Alchemy Ethereum API');
+  if (!ethNetworkUrl.includes('alchemy') && !ethNetworkUrl.includes('infura'))
+    throw new Error('Must use Alchemy or Infura Ethereum API');
   if (process && process.env) {
-    const { ALCHEMY_API_KEY } = process.env;
+    // TODO: alchemy keys are different per network, so we need to ensure we have the correct
+    //   keys for arbitrary networks
+    let ALCHEMY_API_KEY;
+    if (ethNetworkUrl.includes('ropsten')) {
+      ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY_ROPSTEN;
+      ethNetworkUrl = `wss://eth-ropsten.alchemyapi.io/v2/${ALCHEMY_API_KEY}`;
+    } else if (ethNetworkUrl.includes('mainnet')) {
+      ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY;
+      ethNetworkUrl = `wss://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_API_KEY}`;
+    } else {
+      throw new Error('Must be on either ropsten or mainnet');
+    }
     if (!ALCHEMY_API_KEY) {
-      throw new Error('no alchemy api key found!');
+      throw new Error('Alchemy API key not found, check your .env file');
     }
 
-    const networkPrefix = ethNetworkUrl.split('alchemy')[0];
-
-    ethNetworkUrl = `${networkPrefix}alchemyapi.io/v2/${ALCHEMY_API_KEY}`;
-
-    let res;
-    let data;
     try {
-      res = await fetch(
-        `https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
-        {
-          method: 'POST',
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            method: 'eth_getBalance',
-            params: ['0xBf4eD7b27F1d666546E30D74d50d173d20bca754', 'latest'],
-            id: 1,
-          }),
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-
-      data = await res.json();
-
-      if (
-        !data ||
-        !Object.keys(data).includes('jsonrpc') ||
-        !Object.keys(data).includes('id') ||
-        !Object.keys(data).includes('result')
-      )
+      const web3Provider = new Web3.providers.WebsocketProvider(ethNetworkUrl, {
+        reconnect: {
+          auto: false,
+        },
+      });
+      const provider = new providers.Web3Provider(web3Provider);
+      // 12s minute polling interval (default is 4s)
+      provider.pollingInterval = 12000;
+      const data = await provider.getBlock('latest');
+      if (!data)
         throw new Error('A connection to Alchemy could not be established.');
+      return provider;
     } catch (error) {
-      log.error('Check your ALCHEMY_API_KEY');
+      log.error(`Failed to connect on ${ethNetworkUrl}`);
+      log.error(`Check your ALCHEMY_API_KEY: ${error.message}`);
       throw error;
     }
   } else {
     throw new Error('must use nodejs to connect to Alchemy provider!');
   }
-
-  const web3Provider = new Web3.providers.WebsocketProvider(ethNetworkUrl, {
-    reconnect: {
-      auto: false,
-    },
-  });
-  const provider = new providers.Web3Provider(web3Provider);
-  // 12s minute polling interval (default is 4s)
-  provider.pollingInterval = 12000;
-  return provider;
 }


### PR DESCRIPTION
Changes the provider from Infura to Alchemy to fix missing chain-events as brought up by dydx.

Switching because Infura has a history of being incompatible with Ethers.js contract listeners.

Tested by listening to dydx contract and checking for missing events by comparing CE returned events against https://etherscan.io/address/0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2#events

This PR also adds a new `listenerV2.ts` script which works the same way as the original `listener.ts` script except it utilizes the `Listener` classes instead of `subscribeEvents()`. This facilitates testing the `Listener` class.

To be merged AFTER Commonwealth Alchemy account is setup and ready.