### PR TITLE
Replace EventChains with SupportedNetwork.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonwealth/chain-events",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "Listen to various chains for events.",
   "license": "GPL-3.0",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonwealth/chain-events",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Listen to various chains for events.",
   "license": "GPL-3.0",
   "files": [

--- a/scripts/batchPoller.ts
+++ b/scripts/batchPoller.ts
@@ -2,7 +2,7 @@ import { spec } from '@edgeware/node-types';
 import { ApiPromise } from '@polkadot/api';
 import { LogGroupControlSettings } from 'typescript-logging';
 import {
-  chainSupportedBy, SubstrateEvents, EventSupportingChains, IEventHandler, IDisconnectedRange, CWEvent, SubstrateTypes
+  chainSupportedBy, SubstrateEvents, IEventHandler, IDisconnectedRange, CWEvent, SubstrateTypes
 } from '../dist/index';
 import { factoryControl } from '../dist/logging';
 
@@ -94,9 +94,6 @@ class StandaloneEventHandler extends IEventHandler {
 function main() {
   const args = process.argv.slice(2);
   const chain = args[0] || 'edgeware';
-  if (!chainSupportedBy(chain, EventSupportingChains)) {
-    throw new Error(`invalid chain: ${args[0]}`);
-  }
   console.log(`Listening to events on ${chain}.`);
 
   const networks = {
@@ -108,12 +105,10 @@ function main() {
   const url = networks[chain];
 
   if (!url) throw new Error(`no url for chain ${chain}`);
-  if (chainSupportedBy(chain, SubstrateEvents.Types.EventChains)) {
-    SubstrateEvents.createApi(url, spec).then(async (api) => {
-      await batchQuery(api, [ new StandaloneEventHandler() ]);
-      process.exit(0);
-    });
-  }
+  SubstrateEvents.createApi(url, spec).then(async (api) => {
+    await batchQuery(api, [ new StandaloneEventHandler() ]);
+    process.exit(0);
+  });
 }
 
 main();

--- a/scripts/listener.ts
+++ b/scripts/listener.ts
@@ -2,15 +2,14 @@
 /* eslint-disable no-console */
 
 import {
-  chainSupportedBy,
   IEventHandler,
   CWEvent,
   SubstrateEvents,
   CompoundEvents,
   MolochEvents,
-  EventSupportingChains,
   AaveEvents,
   Erc20Events,
+  SupportedNetwork,
 } from '../src/index';
 
 import { contracts, networkSpecs, networkUrls } from './listenerUtils';
@@ -26,8 +25,13 @@ const { argv } = yargs
   .options({
     network: {
       alias: 'n',
-      choices: EventSupportingChains,
+      choices: Object.values(SupportedNetwork),
       demandOption: true,
+      description: 'network listener to use',
+    },
+    chain: {
+      alias: 'c',
+      type: 'string',
       description: 'chain to listen on',
     },
     url: {
@@ -36,12 +40,12 @@ const { argv } = yargs
       description: 'node url',
     },
     contractAddress: {
-      alias: 'c',
+      alias: 'a',
       type: 'string',
       description: 'eth contract address',
     },
     archival: {
-      alias: 'a',
+      alias: 'A',
       type: 'boolean',
       description: 'run listener in archival mode or not',
     },
@@ -53,17 +57,24 @@ const { argv } = yargs
     },
   })
   .check((data) => {
-    if (
-      !chainSupportedBy(data.network, SubstrateEvents.Types.EventChains) &&
-      data.spec
-    ) {
-      throw new Error('cannot pass spec on non-substrate network');
+    if (!data.url && !data.chain) {
+      throw new Error('Must pass either URL or chain name!');
+    }
+    if (!networkUrls[data.chain] || !data.url) {
+      throw new Error(`no URL found for ${data.chain}`);
     }
     if (
-      !chainSupportedBy(data.network, MolochEvents.Types.EventChains) &&
-      data.contractAddress
+      data.network !== SupportedNetwork.Substrate &&
+      !data.contractAddress &&
+      !contracts[data.chain]
     ) {
-      throw new Error('cannot pass contract address on non-moloch network');
+      throw new Error(`no contract found for ${data.chain}`);
+    }
+    if (
+      data.network === SupportedNetwork.Substrate &&
+      !networkSpecs[data.chain]
+    ) {
+      throw new Error(`no spec found for ${data.chain}`);
     }
     return true;
   });
@@ -72,9 +83,11 @@ const { archival } = argv;
 // if running in archival mode then which block shall we star from
 const startBlock: number = argv.startBlock ?? 0;
 const { network } = argv;
-const url: string = argv.url || networkUrls[network];
-const spec = networkSpecs[network] || {};
-const contract: string | undefined = argv.contractAddress || contracts[network];
+const chain = argv.chain || 'dummy';
+const url = argv.url || networkUrls[chain];
+const spec = networkSpecs[chain];
+const contract = argv.contractAddress || contracts[chain];
+
 class StandaloneEventHandler extends IEventHandler {
   // eslint-disable-next-line class-methods-use-this
   public async handle(event: CWEvent): Promise<null> {
@@ -105,8 +118,9 @@ async function getTokenLists() {
     .flat()
     .filter((o) => o);
 }
-console.log(`Connecting to ${network} on url ${url}...`);
-if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
+console.log(`Connecting to ${chain} on url ${url}...`);
+
+if (network === SupportedNetwork.Substrate) {
   SubstrateEvents.createApi(url, spec as any).then(async (api) => {
     const fetcher = new SubstrateEvents.StorageFetcher(api);
     try {
@@ -117,7 +131,7 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
       console.error(`Got error from fetcher: ${JSON.stringify(err, null, 2)}.`);
     }
     SubstrateEvents.subscribeEvents({
-      chain: network,
+      chain,
       api,
       handlers: [new StandaloneEventHandler()],
       skipCatchup,
@@ -127,9 +141,8 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
       enricherConfig: { balanceTransferThresholdPermill: 1_000 }, // 0.1% of total issuance
     });
   });
-} else if (chainSupportedBy(network, MolochEvents.Types.EventChains)) {
+} else if (network === SupportedNetwork.Moloch) {
   const contractVersion = 1;
-  if (!contract) throw new Error(`no contract address for ${network}`);
   MolochEvents.createApi(url, contractVersion, contract).then(async (api) => {
     const dater = new EthDater(api.provider);
     const fetcher = new MolochEvents.StorageFetcher(
@@ -149,7 +162,7 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
       console.error(`Got error from fetcher: ${JSON.stringify(err, null, 2)}.`);
     }
     MolochEvents.subscribeEvents({
-      chain: network,
+      chain,
       api,
       contractVersion,
       handlers: [new StandaloneEventHandler()],
@@ -157,8 +170,7 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
       verbose: true,
     });
   });
-} else if (chainSupportedBy(network, CompoundEvents.Types.EventChains)) {
-  if (!contract) throw new Error(`no contract address for ${network}`);
+} else if (network === SupportedNetwork.Compound) {
   CompoundEvents.createApi(url, contract).then(async (api) => {
     const fetcher = new CompoundEvents.StorageFetcher(api);
     try {
@@ -173,15 +185,14 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
       console.error(`Got error from fetcher: ${JSON.stringify(err, null, 2)}.`);
     }
     CompoundEvents.subscribeEvents({
-      chain: network,
+      chain,
       api,
       handlers: [new StandaloneEventHandler()],
       skipCatchup,
       verbose: true,
     });
   });
-} else if (chainSupportedBy(network, AaveEvents.Types.EventChains)) {
-  if (!contract) throw new Error(`no contract address for ${network}`);
+} else if (network === SupportedNetwork.Aave) {
   AaveEvents.createApi(url, contract).then(async (api) => {
     const fetcher = new AaveEvents.StorageFetcher(api);
     try {
@@ -196,20 +207,20 @@ if (chainSupportedBy(network, SubstrateEvents.Types.EventChains)) {
       console.error(`Got error from fetcher: ${JSON.stringify(err, null, 2)}.`);
     }
     AaveEvents.subscribeEvents({
-      chain: network,
+      chain,
       api,
       handlers: [new StandaloneEventHandler()],
       skipCatchup,
       verbose: true,
     });
   });
-} else if (chainSupportedBy(network, Erc20Events.Types.EventChains)) {
+} else if (network === SupportedNetwork.ERC20) {
   getTokenLists().then(async (tokens) => {
     const tokenAddresses = tokens.map((o) => o.address);
     const tokenNames = tokens.map((o) => o.name);
     const api = await Erc20Events.createApi(url, tokenAddresses, tokenNames);
     Erc20Events.subscribeEvents({
-      chain: network,
+      chain,
       api,
       handlers: [new StandaloneEventHandler()],
       skipCatchup,

--- a/scripts/listener.ts
+++ b/scripts/listener.ts
@@ -60,7 +60,7 @@ const { argv } = yargs
     if (!data.url && !data.chain) {
       throw new Error('Must pass either URL or chain name!');
     }
-    if (!networkUrls[data.chain] || !data.url) {
+    if (!networkUrls[data.chain] && !data.url) {
       throw new Error(`no URL found for ${data.chain}`);
     }
     if (

--- a/scripts/listenerUtils.ts
+++ b/scripts/listenerUtils.ts
@@ -41,6 +41,8 @@ export const networkSpecs: { [chain: string]: RegisteredTypes } = {
   'edgeware-local': EdgewareSpec,
   'edgeware-testnet': EdgewareSpec,
   stafi: StafiSpec,
+  kusama: {},
+  polkadot: {},
 };
 
 export const contracts = {

--- a/scripts/listenerV2.ts
+++ b/scripts/listenerV2.ts
@@ -1,13 +1,18 @@
-import * as yargs from 'yargs';
+import { createListener, LoggingHandler, SupportedNetwork } from '../src';
 
-import { createListener, EventSupportingChains, LoggingHandler } from '../src';
+import * as yargs from 'yargs';
 
 const { argv } = yargs.options({
   network: {
     alias: 'n',
-    choices: EventSupportingChains,
+    choices: Object.values(SupportedNetwork),
     demandOption: true,
-    description: 'chain to listen on',
+    description: 'network to listen on',
+  },
+  chain: {
+    alias: 'c',
+    type: 'string',
+    description: 'name of chain to listen on',
   },
   url: {
     alias: 'u',
@@ -15,12 +20,12 @@ const { argv } = yargs.options({
     description: 'node url',
   },
   contractAddress: {
-    alias: 'c',
+    alias: 'a',
     type: 'string',
     description: 'eth contract address',
   },
   tokenName: {
-    alias: 'a',
+    alias: 't',
     type: 'string',
     description:
       'Name of the token if network is erc20 and contractAddress is a erc20 token address',
@@ -30,7 +35,7 @@ const { argv } = yargs.options({
 async function main(): Promise<any> {
   let listener;
   try {
-    listener = await createListener(argv.network, {
+    listener = await createListener(argv.chain || 'dummyChain', argv.network, {
       url: argv.url,
       address: argv.contractAddress,
       tokenAddresses: [argv.contractAddress],

--- a/scripts/scraper.ts
+++ b/scripts/scraper.ts
@@ -1,5 +1,5 @@
 import { spec } from '@edgeware/node-types';
-import { chainSupportedBy, SubstrateEvents, EventSupportingChains, SubstrateTypes } from '../dist/index';
+import { SubstrateEvents, SubstrateTypes } from '../dist/index';
 import { Registration } from '@polkadot/types/interfaces';
 import { Option } from '@polkadot/types';
 import { ParseType } from '../dist/substrate/filters/type_parser';
@@ -7,9 +7,6 @@ import fs from 'fs';
 
 const args = process.argv.slice(2);
 const chain = args[0] || 'edgeware';
-if (!chainSupportedBy(chain, EventSupportingChains)) {
-  throw new Error(`invalid chain: ${args[0]}`);
-}
 console.log(`Listening to events on ${chain}.`);
 
 const networks = {
@@ -21,43 +18,41 @@ const networks = {
 const url = networks[chain];
 
 if (!url) throw new Error(`no url for chain ${chain}`);
-if (chainSupportedBy(chain, SubstrateEvents.Types.EventChains)) {
-  SubstrateEvents.createApi(url, spec).then(async (api) => {
-    const subscriber = new SubstrateEvents.Subscriber(api);
-    const identities = {};
-    const FINISH_BLOCK = 1000000;
-    subscriber.subscribe(async (block) => {
-      // go through events and add new identities
-      for (const { event } of block.events) {
-        const kind = ParseType(block.versionName, block.versionNumber, event.section, event.method);
-        if (kind === SubstrateTypes.EventKind.IdentitySet) {
-          // query the entire identity data
-          const who = event.data[0].toString();
-          const registrationOpt = await api.query.identity.identityOf<Option<Registration>>(who);
+SubstrateEvents.createApi(url, spec as any).then(async (api) => {
+  const subscriber = new SubstrateEvents.Subscriber(api);
+  const identities = {};
+  const FINISH_BLOCK = 1000000;
+  subscriber.subscribe(async (block) => {
+    // go through events and add new identities
+    for (const { event } of block.events) {
+      const kind = ParseType(block.versionName, block.versionNumber, event.section, event.method);
+      if (kind === SubstrateTypes.EventKind.IdentitySet) {
+        // query the entire identity data
+        const who = event.data[0].toString();
+        const registrationOpt = await api.query.identity.identityOf<Option<Registration>>(who);
 
-          // if the identity data exists, populate the object
-          if (registrationOpt.isSome) {
-            const { info } = registrationOpt.unwrap();
-            identities[who] = info;
-          }
-        } if (kind === SubstrateTypes.EventKind.IdentityCleared || kind === SubstrateTypes.EventKind.IdentityKilled) {
-          // clear deleted identities from our scaped object
-          const who = event.data[0].toString();
-          if (identities[who]) {
-            delete identities[who];
-          }
+        // if the identity data exists, populate the object
+        if (registrationOpt.isSome) {
+          const { info } = registrationOpt.unwrap();
+          identities[who] = info;
+        }
+      } if (kind === SubstrateTypes.EventKind.IdentityCleared || kind === SubstrateTypes.EventKind.IdentityKilled) {
+        // clear deleted identities from our scaped object
+        const who = event.data[0].toString();
+        if (identities[who]) {
+          delete identities[who];
         }
       }
+    }
 
-      // check for completion
-      if (+block.header.number >= FINISH_BLOCK) {
-        subscriber.unsubscribe();
+    // check for completion
+    if (+block.header.number >= FINISH_BLOCK) {
+      subscriber.unsubscribe();
 
-        // write identities out to file and exit
-        fs.writeFileSync('./identities.json', JSON.stringify(identities, null, 2));
-        await api.disconnect();
-        process.exit(0);
-      }
-    });
+      // write identities out to file and exit
+      fs.writeFileSync('./identities.json', JSON.stringify(identities, null, 2));
+      await api.disconnect();
+      process.exit(0);
+    }
   });
-}
+});

--- a/src/Listener.ts
+++ b/src/Listener.ts
@@ -3,7 +3,6 @@ import {
   IChainEventKind,
   IEventSubscriber,
   IEventProcessor,
-  EventSupportingChainT,
   IChainEventData,
   CWEvent,
   IStorageFetcher,
@@ -50,7 +49,7 @@ export abstract class Listener<
 
   protected readonly _verbose: boolean;
 
-  protected constructor(chain: EventSupportingChainT, verbose?: boolean) {
+  protected constructor(chain: string, verbose?: boolean) {
     this._chain = chain;
     this.eventHandlers = {};
     this._verbose = !!verbose;
@@ -81,7 +80,7 @@ export abstract class Listener<
   protected async handleEvent(event: CWEvent<IChainEventData>): Promise<void> {
     let prevResult;
 
-    event.chain = this._chain as EventSupportingChainT;
+    event.chain = this._chain;
     event.received = Date.now();
 
     for (const key of Object.keys(this.eventHandlers)) {

--- a/src/chains/aave/Listener.ts
+++ b/src/chains/aave/Listener.ts
@@ -1,15 +1,9 @@
 import { Listener as BaseListener } from '../../Listener';
-import {
-  chainSupportedBy,
-  CWEvent,
-  EventSupportingChainT,
-  IDisconnectedRange,
-} from '../../interfaces';
+import { CWEvent, IDisconnectedRange } from '../../interfaces';
 import { factory, formatFilename } from '../../logging';
 
 import {
   ListenerOptions as AaveListenerOptions,
-  EventChains as AaveEventChains,
   EventKind,
   IEventData,
   RawEvent,
@@ -34,18 +28,14 @@ export class Listener extends BaseListener<
   private readonly _options: AaveListenerOptions;
 
   constructor(
-    chain: EventSupportingChainT,
+    chain: string,
     govContractAddress: string,
     url?: string,
     skipCatchup?: boolean,
     verbose?: boolean,
-    ignoreChainType?: boolean,
     discoverReconnectRange?: (c: string) => Promise<IDisconnectedRange>
   ) {
     super(chain, verbose);
-    if (!ignoreChainType && !chainSupportedBy(this._chain, AaveEventChains))
-      throw new Error(`${this._chain} is not an Aave chain`);
-
     this._options = {
       url,
       govContractAddress,

--- a/src/chains/aave/filters/enricher.ts
+++ b/src/chains/aave/filters/enricher.ts
@@ -3,7 +3,7 @@ import { BigNumber } from 'ethers';
 
 import { TypedEventFilter } from '../../../contractTypes/commons';
 import { AaveTokenV2, IAaveGovernanceV2 } from '../../../contractTypes';
-import { CWEvent } from '../../../interfaces';
+import { CWEvent, SupportedNetwork } from '../../../interfaces';
 import { EventKind, RawEvent, IEventData, Api } from '../types';
 
 type GetEventArgs<T> = T extends TypedEventFilter<any, infer Y> ? Y : never;
@@ -26,6 +26,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           id: +id,
@@ -53,6 +54,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [creator],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           id: +id,
@@ -74,6 +76,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           id: +id,
@@ -87,6 +90,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           id: +id,
@@ -101,6 +105,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [voter],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           id: +id,
@@ -119,6 +124,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [delegator],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           tokenAddress: rawData.address,
@@ -135,6 +141,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [user],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           tokenAddress: rawData.address,
@@ -149,6 +156,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [from],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           tokenAddress: rawData.address,
@@ -165,6 +173,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [owner],
+        network: SupportedNetwork.Aave,
         data: {
           kind,
           tokenAddress: rawData.address,
@@ -179,5 +188,5 @@ export async function Enrich(
     }
   }
 
-  return { blockNumber: null, data: null };
+  return { blockNumber: null, network: SupportedNetwork.Aave, data: null };
 }

--- a/src/chains/aave/storageFetcher.ts
+++ b/src/chains/aave/storageFetcher.ts
@@ -75,7 +75,7 @@ export class StorageFetcher extends IStorageFetcher<Api> {
       return [];
     }
     log.info(
-      `Fetching Compound entities for range: ${range.startBlock}-${range.endBlock}.`
+      `Fetching Aave entities for range: ${range.startBlock}-${range.endBlock}.`
     );
 
     const proposalCreatedEvents = await this._api.governance.queryFilter(

--- a/src/chains/aave/types.ts
+++ b/src/chains/aave/types.ts
@@ -27,13 +27,6 @@ export interface ListenerOptions {
 
 export type Api = IAaveContracts;
 
-export const EventChains = [
-  'aave',
-  'aave-local',
-  'dydx-ropsten',
-  'dydx',
-] as const;
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RawEvent = TypedEvent<any>;
 

--- a/src/chains/compound/Listener.ts
+++ b/src/chains/compound/Listener.ts
@@ -1,9 +1,4 @@
-import {
-  chainSupportedBy,
-  CWEvent,
-  EventSupportingChainT,
-  IDisconnectedRange,
-} from '../../interfaces';
+import { CWEvent, IDisconnectedRange } from '../../interfaces';
 import { Listener as BaseListener } from '../../Listener';
 import { factory, formatFilename } from '../../logging';
 
@@ -11,7 +6,6 @@ import {
   ListenerOptions as CompoundListenerOptions,
   RawEvent,
   Api,
-  EventChains as CompoundChains,
   IEventData,
   EventKind,
 } from './types';
@@ -32,7 +26,7 @@ export class Listener extends BaseListener<
   private readonly _options: CompoundListenerOptions;
 
   constructor(
-    chain: EventSupportingChainT,
+    chain: string,
     contractAddress: string,
     url?: string,
     skipCatchup?: boolean,
@@ -40,9 +34,6 @@ export class Listener extends BaseListener<
     discoverReconnectRange?: (c: string) => Promise<IDisconnectedRange>
   ) {
     super(chain, verbose);
-    if (!chainSupportedBy(this._chain, CompoundChains))
-      throw new Error(`${this._chain} is not a Compound contract`);
-
     this._options = {
       url,
       skipCatchup: !!skipCatchup,

--- a/src/chains/compound/filters/enricher.ts
+++ b/src/chains/compound/filters/enricher.ts
@@ -3,7 +3,7 @@ import { Contract, utils } from 'ethers';
 
 import { GovernorBravoDelegate as GovernorBravo } from '../../../contractTypes';
 import { TypedEventFilter } from '../../../contractTypes/commons';
-import { CWEvent } from '../../../interfaces';
+import { CWEvent, SupportedNetwork } from '../../../interfaces';
 import { EventKind, RawEvent, IEventData, Api } from '../types';
 
 type GetEventArgs<T> = T extends TypedEventFilter<infer Y, any> ? Y : never;
@@ -27,6 +27,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [],
+        network: SupportedNetwork.Compound,
         data: {
           kind,
           id: id.toHexString(),
@@ -71,6 +72,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [proposer],
+        network: SupportedNetwork.Compound,
         data: {
           kind,
           id: id.toHexString(),
@@ -93,6 +95,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [],
+        network: SupportedNetwork.Compound,
         data: {
           kind,
           id: id.toHexString(),
@@ -107,6 +110,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [],
+        network: SupportedNetwork.Compound,
         data: {
           kind,
           id: id.toHexString(),
@@ -125,6 +129,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [voter],
+        network: SupportedNetwork.Compound,
         data: {
           kind,
           voter,

--- a/src/chains/compound/types.ts
+++ b/src/chains/compound/types.ts
@@ -21,15 +21,6 @@ export enum BravoSupport {
 
 export type Api = GovernorAlpha;
 
-// TODO: clarify how this section works
-export const EventChains = [
-  'compound',
-  'marlin-local',
-  'marlin',
-  'uniswap',
-  'tribe',
-] as const;
-
 // options for the listener class
 export interface ListenerOptions {
   url: string;

--- a/src/chains/erc20/Listener.ts
+++ b/src/chains/erc20/Listener.ts
@@ -1,15 +1,10 @@
-import {
-  chainSupportedBy,
-  CWEvent,
-  EventSupportingChainT,
-} from '../../interfaces';
+import { CWEvent } from '../../interfaces';
 import { Listener as BaseListener } from '../../Listener';
 import { factory, formatFilename } from '../../logging';
 
 import {
   ListenerOptions as Erc20ListenerOptions,
   RawEvent,
-  EventChains as erc20Chains,
   IErc20Contracts,
   EventKind,
 } from './types';
@@ -30,18 +25,14 @@ export class Listener extends BaseListener<
   private readonly _options: Erc20ListenerOptions;
 
   constructor(
-    chain: EventSupportingChainT,
+    chain: string,
     tokenAddresses: string[],
     url?: string,
     tokenNames?: string[],
     enricherConfig?: EnricherConfig,
-    verbose?: boolean,
-    ignoreChainType?: boolean
+    verbose?: boolean
   ) {
     super(chain, verbose);
-    if (!ignoreChainType && !chainSupportedBy(this._chain, erc20Chains))
-      throw new Error(`${chain} is not an ERC20 token`);
-
     this._options = {
       url,
       tokenAddresses,

--- a/src/chains/erc20/filters/enricher.ts
+++ b/src/chains/erc20/filters/enricher.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js';
 
-import { CWEvent } from '../../../interfaces';
+import { CWEvent, SupportedNetwork } from '../../../interfaces';
 import { TypedEventFilter } from '../../../contractTypes/commons';
 import { ERC20 } from '../../../contractTypes';
 import { EventKind, RawEvent, IEventData, IErc20Contracts } from '../types';
@@ -63,6 +63,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses,
+        network: SupportedNetwork.ERC20,
         data: {
           kind,
           owner,
@@ -96,6 +97,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses,
+        network: SupportedNetwork.ERC20,
         data: {
           kind,
           from,

--- a/src/chains/erc20/types.ts
+++ b/src/chains/erc20/types.ts
@@ -24,8 +24,6 @@ export interface ListenerOptions {
   enricherConfig: EnricherConfig;
 }
 
-export const EventChains = ['erc20'] as const;
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RawEvent = TypedEvent<any>;
 

--- a/src/chains/moloch/Listener.ts
+++ b/src/chains/moloch/Listener.ts
@@ -1,11 +1,6 @@
 import EthDater from 'ethereum-block-by-date';
 
-import {
-  chainSupportedBy,
-  CWEvent,
-  EventSupportingChainT,
-  IDisconnectedRange,
-} from '../../interfaces';
+import { CWEvent, IDisconnectedRange } from '../../interfaces';
 import { Listener as BaseListener } from '../../Listener';
 import { factory, formatFilename } from '../../logging';
 
@@ -13,7 +8,6 @@ import {
   EventKind,
   Api,
   RawEvent,
-  EventChains as molochChains,
   ListenerOptions as MolochListenerOptions,
   IEventData,
 } from './types';
@@ -32,7 +26,7 @@ export class Listener extends BaseListener<
   private readonly _options: MolochListenerOptions;
 
   constructor(
-    chain: EventSupportingChainT,
+    chain: string,
     contractVersion?: 1 | 2,
     contractAddress?: string,
     url?: string,
@@ -41,9 +35,6 @@ export class Listener extends BaseListener<
     discoverReconnectRange?: (c: string) => Promise<IDisconnectedRange>
   ) {
     super(chain, verbose);
-    if (!chainSupportedBy(this._chain, molochChains))
-      throw new Error(`${this._chain} is not a moloch network`);
-
     this._options = {
       url,
       skipCatchup: !!skipCatchup,

--- a/src/chains/moloch/filters/enricher.ts
+++ b/src/chains/moloch/filters/enricher.ts
@@ -4,7 +4,7 @@ import { hexToNumberString, hexToNumber as web3HexToNumber } from 'web3-utils';
 
 import { TypedEventFilter } from '../../../contractTypes/commons';
 import { Moloch1 } from '../../../contractTypes';
-import { CWEvent } from '../../../interfaces';
+import { CWEvent, SupportedNetwork } from '../../../interfaces';
 import { EventKind, RawEvent, IEventData, Api } from '../types';
 
 type GetEventArgs<T> = T extends TypedEventFilter<any, infer Y> ? Y : never;
@@ -57,6 +57,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [memberAddress],
+        network: SupportedNetwork.Moloch,
         data: {
           kind,
           proposalIndex: hexToNumber(proposalIndex),
@@ -81,6 +82,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [memberAddress],
+        network: SupportedNetwork.Moloch,
         data: {
           kind,
           proposalIndex: hexToNumber(proposalIndex),
@@ -104,6 +106,7 @@ export async function Enrich(
       const proposal = await (api as Moloch1).proposalQueue(proposalIndex);
       return {
         blockNumber,
+        network: SupportedNetwork.Moloch,
         data: {
           kind,
           proposalIndex: hexToNumber(proposalIndex),
@@ -125,6 +128,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [memberAddress],
+        network: SupportedNetwork.Moloch,
         data: {
           kind,
           member: memberAddress,
@@ -140,6 +144,7 @@ export async function Enrich(
       return {
         blockNumber,
         excludeAddresses: [applicantAddress],
+        network: SupportedNetwork.Moloch,
         data: {
           kind,
           proposalIndex: hexToNumber(proposalIndex),
@@ -157,6 +162,7 @@ export async function Enrich(
         // TODO: we only alert the new delegate that the key was changed
         //   ...is this correct?
         includeAddresses: [newDelegateKey],
+        network: SupportedNetwork.Moloch,
         data: {
           kind,
           member: memberAddress,
@@ -171,6 +177,7 @@ export async function Enrich(
       >;
       return {
         blockNumber,
+        network: SupportedNetwork.Moloch,
         data: {
           kind,
           summoner,

--- a/src/chains/moloch/storageFetcher.ts
+++ b/src/chains/moloch/storageFetcher.ts
@@ -1,6 +1,11 @@
 import EthDater from 'ethereum-block-by-date';
 
-import { CWEvent, IStorageFetcher, IDisconnectedRange } from '../../interfaces';
+import {
+  CWEvent,
+  IStorageFetcher,
+  IDisconnectedRange,
+  SupportedNetwork,
+} from '../../interfaces';
 import { factory, formatFilename } from '../../logging';
 import { Moloch1, Moloch2 } from '../../contractTypes';
 
@@ -46,6 +51,7 @@ export class StorageFetcher extends IStorageFetcher<Api> {
     if (this._isProposalV1(proposal)) {
       const proposedEvent: CWEvent<IEventData> = {
         blockNumber: startBlock,
+        network: SupportedNetwork.Moloch,
         data: {
           kind: EventKind.SubmitProposal,
           proposalIndex: index,
@@ -86,6 +92,7 @@ export class StorageFetcher extends IStorageFetcher<Api> {
 
         const abortedEvent: CWEvent<IEventData> = {
           blockNumber,
+          network: SupportedNetwork.Moloch,
           data: {
             kind: EventKind.Abort,
             proposalIndex: index,
@@ -117,6 +124,7 @@ export class StorageFetcher extends IStorageFetcher<Api> {
 
         const processedEvent: CWEvent<IEventData> = {
           blockNumber,
+          network: SupportedNetwork.Moloch,
           data: {
             kind: EventKind.ProcessProposal,
             proposalIndex: index,

--- a/src/chains/moloch/types.ts
+++ b/src/chains/moloch/types.ts
@@ -12,8 +12,6 @@ export type ProposalV2 = UnPromisify<
 
 export type Api = Moloch1 | Moloch2;
 
-export const EventChains = ['moloch', 'moloch-local'] as const;
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RawEvent = TypedEvent<any>;
 

--- a/src/chains/substrate/Listener.ts
+++ b/src/chains/substrate/Listener.ts
@@ -1,22 +1,11 @@
 import { ApiPromise } from '@polkadot/api';
 import { RegisteredTypes } from '@polkadot/types/types';
 
-import {
-  chainSupportedBy,
-  CWEvent,
-  EventSupportingChainT,
-  IDisconnectedRange,
-  IEventPoller,
-} from '../../interfaces';
+import { CWEvent, IDisconnectedRange, IEventPoller } from '../../interfaces';
 import { Listener as BaseListener } from '../../Listener';
 import { factory, formatFilename } from '../../logging';
 
-import {
-  EventChains as SubstrateChains,
-  EventKind,
-  Block,
-  ISubstrateListenerOptions,
-} from './types';
+import { EventKind, Block, ISubstrateListenerOptions } from './types';
 
 import {
   createApi,
@@ -44,7 +33,7 @@ export class Listener extends BaseListener<
   public discoverReconnectRange: (chain: string) => Promise<IDisconnectedRange>;
 
   constructor(
-    chain: EventSupportingChainT,
+    chain: string,
     url?: string,
     spec?: RegisteredTypes,
     archival?: boolean,
@@ -52,14 +41,9 @@ export class Listener extends BaseListener<
     skipCatchup?: boolean,
     enricherConfig?: EnricherConfig,
     verbose?: boolean,
-    ignoreChainType?: boolean,
     discoverReconnectRange?: (c: string) => Promise<IDisconnectedRange>
   ) {
     super(chain, verbose);
-    // if ignoreChainType = true ignore the hard-coded EventChains type
-    if (!ignoreChainType && !chainSupportedBy(this._chain, SubstrateChains))
-      throw new Error(`${this._chain} is not a Substrate chain`);
-
     this._options = {
       archival: !!archival,
       startBlock: startBlock ?? 0,

--- a/src/chains/substrate/filters/enricher.ts
+++ b/src/chains/substrate/filters/enricher.ts
@@ -41,7 +41,7 @@ import {
   OffenceDetails,
 } from '@polkadot/types/interfaces/offences';
 
-import { CWEvent } from '../../../interfaces';
+import { CWEvent, SupportedNetwork } from '../../../interfaces';
 import {
   EventKind,
   IEventData,
@@ -1324,5 +1324,7 @@ export async function Enrich(
   const eventData = await (isEvent(rawData)
     ? extractEventData(rawData as Event)
     : extractExtrinsicData(rawData as Extrinsic));
-  return eventData ? { ...eventData, blockNumber } : null;
+  return eventData
+    ? { ...eventData, blockNumber, network: SupportedNetwork.Substrate }
+    : null;
 }

--- a/src/chains/substrate/filters/labeler.ts
+++ b/src/chains/substrate/filters/labeler.ts
@@ -1,7 +1,7 @@
 import BN from 'bn.js';
 
 import { IEventLabel, LabelerFilter } from '../../../interfaces';
-import { BalanceString, EventKind, IEventData, EventChains } from '../types';
+import { BalanceString, EventKind, IEventData } from '../types';
 
 function fmtAddr(addr: string) {
   if (!addr) return '';
@@ -45,7 +45,7 @@ function formatNumberShort(num: number) {
     : num.toString();
 }
 
-const getDenom = (chain: typeof EventChains[number]): string => {
+const getDenom = (chain: string): string => {
   switch (chain) {
     case 'clover':
       return 'CLV';
@@ -69,17 +69,12 @@ const getDenom = (chain: typeof EventChains[number]): string => {
     case 'polkadot-local':
       return 'tDOT';
     default: {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const _dummy: never = chain;
       throw new Error('invalid chain');
     }
   }
 };
 
-const edgBalanceFormatter = (
-  chain: typeof EventChains[number],
-  balance: BalanceString
-): string => {
+const edgBalanceFormatter = (chain: string, balance: BalanceString): string => {
   const denom = getDenom(chain);
   let dollar: BN;
   if (chain.startsWith('edgeware')) {
@@ -106,7 +101,7 @@ const edgBalanceFormatter = (
  */
 export const Label: LabelerFilter = (
   blockNumber: number,
-  chainId: typeof EventChains[number],
+  chainId: string,
   data: IEventData
 ): IEventLabel => {
   const balanceFormatter = (bal) => edgBalanceFormatter(chainId, bal);

--- a/src/chains/substrate/storageFetcher.ts
+++ b/src/chains/substrate/storageFetcher.ts
@@ -24,7 +24,12 @@ import { Codec } from '@polkadot/types/types';
 import { DeriveProposalImage } from '@polkadot/api-derive/types';
 import { isFunction, hexToString } from '@polkadot/util';
 
-import { CWEvent, IChainEntityKind, IStorageFetcher } from '../../interfaces';
+import {
+  CWEvent,
+  IChainEntityKind,
+  IStorageFetcher,
+  SupportedNetwork,
+} from '../../interfaces';
 import { factory, formatFilename } from '../../logging';
 
 import {
@@ -99,6 +104,7 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
           return {
             // use current block as "fake" set date
             blockNumber,
+            network: SupportedNetwork.Substrate,
             data: {
               kind: EventKind.IdentitySet,
               who: address,
@@ -253,7 +259,11 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
         .map(([prop, depositOpt]) => constructEvent(prop, depositOpt))
         .filter((e) => !!e);
       log.info(`Found ${proposedEvents.length} democracy proposals!`);
-      return proposedEvents.map((data) => ({ blockNumber, data }));
+      return proposedEvents.map((data) => ({
+        blockNumber,
+        network: SupportedNetwork.Substrate,
+        data,
+      }));
       // eslint-disable-next-line no-else-return
     } else {
       const publicProp = publicProps.find(([idx]) => +idx === +id);
@@ -268,6 +278,7 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
       return [
         {
           blockNumber,
+          network: SupportedNetwork.Substrate,
           data: evt,
         },
       ];
@@ -317,6 +328,7 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
     );
     const results = [...startEvents, ...passedEvents].map((data) => ({
       blockNumber,
+      network: SupportedNetwork.Substrate,
       data,
     }));
 
@@ -366,7 +378,11 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
     });
     const cwEvents = notedEvents
       .filter(([, data]) => !!data)
-      .map(([blockNumber, data]) => ({ blockNumber, data }));
+      .map(([blockNumber, data]) => ({
+        blockNumber,
+        network: SupportedNetwork.Substrate,
+        data,
+      }));
     log.info(`Found ${cwEvents.length} preimages!`);
     return cwEvents;
   }
@@ -394,6 +410,7 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
       return [
         {
           blockNumber,
+          network: SupportedNetwork.Substrate,
           data: {
             kind: EventKind.TreasuryProposed,
             proposalIndex: +id,
@@ -433,7 +450,11 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
       })
       .filter((e) => !!e);
     log.info(`Found ${proposedEvents.length} treasury proposals!`);
-    return proposedEvents.map((data) => ({ blockNumber, data }));
+    return proposedEvents.map((data) => ({
+      blockNumber,
+      network: SupportedNetwork.Substrate,
+      data,
+    }));
   }
 
   public async fetchBounties(
@@ -492,7 +513,11 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
     }
 
     // no easier way to only fetch one than to fetch em all
-    const results = events.map((data) => ({ blockNumber, data }));
+    const results = events.map((data) => ({
+      blockNumber,
+      network: SupportedNetwork.Substrate,
+      data,
+    }));
     if (id !== undefined) {
       const data = results.filter(
         ({ data: { bountyIndex } }) => bountyIndex === +id
@@ -588,7 +613,11 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
         log.error(`No collective proposal found with hash ${id}!`);
         return null;
       }
-      return events.map((data) => ({ blockNumber, data }));
+      return events.map((data) => ({
+        blockNumber,
+        network: SupportedNetwork.Substrate,
+        data,
+      }));
     }
 
     // fetch all
@@ -623,7 +652,11 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
         proposedEvents.length - nProposalEvents
       } votes!`
     );
-    return proposedEvents.map((data) => ({ blockNumber, data }));
+    return proposedEvents.map((data) => ({
+      blockNumber,
+      network: SupportedNetwork.Substrate,
+      data,
+    }));
   }
 
   public async fetchTips(
@@ -661,6 +694,7 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
               // newtip events
               results.push({
                 blockNumber,
+                network: SupportedNetwork.Substrate,
                 data: {
                   kind: EventKind.NewTip,
                   proposalHash: h,
@@ -676,6 +710,7 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
               for (const [voter, amount] of tipVotes) {
                 results.push({
                   blockNumber,
+                  network: SupportedNetwork.Substrate,
                   data: {
                     kind: EventKind.TipVoted,
                     proposalHash: h,
@@ -690,6 +725,7 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
                 const closesAt = +closes.unwrap();
                 results.push({
                   blockNumber,
+                  network: SupportedNetwork.Substrate,
                   data: {
                     kind: EventKind.TipClosing,
                     proposalHash: h,
@@ -824,7 +860,11 @@ export class StorageFetcher extends IStorageFetcher<ApiPromise> {
       ...completedEvents,
     ];
     // we could plausibly populate the completed events with block numbers, but not necessary
-    const results = events.map((data) => ({ blockNumber, data }));
+    const results = events.map((data) => ({
+      blockNumber,
+      network: SupportedNetwork.Substrate,
+      data,
+    }));
 
     // no easier way to only fetch one than to fetch em all
     if (id !== undefined) {

--- a/src/chains/substrate/types.ts
+++ b/src/chains/substrate/types.ts
@@ -9,20 +9,6 @@ import { RegisteredTypes } from '@polkadot/types/types';
 
 import { EnricherConfig } from './filters/enricher';
 
-export const EventChains = [
-  'clover',
-  'edgeware',
-  'edgeware-local',
-  'edgeware-testnet',
-  'hydradx',
-  'kusama',
-  'kusama-local',
-  'polkadot',
-  'polkadot-local',
-  'kulupu',
-  'stafi',
-] as const;
-
 export interface ISubstrateListenerOptions {
   startBlock: number;
   skipCatchup: boolean;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,6 +57,7 @@ export interface CWEvent<IEventData = IChainEventData> {
   excludeAddresses?: string[];
 
   data: IEventData;
+  network: SupportedNetwork;
   chain?: string;
   received?: number;
 }
@@ -164,7 +165,19 @@ export interface IEventTitle {
 
 export type TitlerFilter = (kind: IChainEventKind) => IEventTitle;
 
-export function entityToFieldName(entity: IChainEntityKind): string | null {
+export function entityToFieldName(
+  network: SupportedNetwork,
+  entity: IChainEntityKind
+): string | null {
+  if (network === SupportedNetwork.Compound) {
+    return 'id';
+  }
+  if (network === SupportedNetwork.Aave) {
+    return 'id';
+  }
+  if (network === SupportedNetwork.Moloch) {
+    return 'proposalIndex';
+  }
   switch (entity) {
     case SubstrateTypes.EntityKind.DemocracyProposal: {
       return 'proposalIndex';
@@ -190,248 +203,268 @@ export function entityToFieldName(entity: IChainEntityKind): string | null {
     case SubstrateTypes.EntityKind.TipProposal: {
       return 'proposalHash';
     }
-    case MolochTypes.EntityKind.Proposal: {
-      return 'proposalIndex';
-    }
-    case CompoundTypes.EntityKind.Proposal: {
-      return 'id';
-    }
-    case AaveTypes.EntityKind.Proposal: {
-      return 'id';
-    }
     default: {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const _exhaustiveMatch: never = entity;
       return null;
     }
   }
 }
 
 export function eventToEntity(
+  network: SupportedNetwork,
   event: IChainEventKind
 ): [IChainEntityKind, EntityEventKind] {
-  switch (event) {
-    // MOLOCH
-    case MolochTypes.EventKind.SubmitProposal: {
-      return [MolochTypes.EntityKind.Proposal, EntityEventKind.Create];
-    }
-    case MolochTypes.EventKind.SubmitVote: {
-      return [MolochTypes.EntityKind.Proposal, EntityEventKind.Vote];
-    }
-    case MolochTypes.EventKind.ProcessProposal: {
-      return [MolochTypes.EntityKind.Proposal, EntityEventKind.Complete];
-    }
-    case MolochTypes.EventKind.Abort: {
-      return [MolochTypes.EntityKind.Proposal, EntityEventKind.Complete];
-    }
-
-    // COMPOUND
-    case CompoundTypes.EventKind.ProposalCanceled: {
-      return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Complete];
-    }
-    case CompoundTypes.EventKind.ProposalCreated: {
-      return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Create];
-    }
-    case CompoundTypes.EventKind.ProposalExecuted: {
-      return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Complete];
-    }
-    case CompoundTypes.EventKind.ProposalQueued: {
-      return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Update];
-    }
-    case CompoundTypes.EventKind.VoteCast: {
-      return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Vote];
-    }
-
-    // AAVE
-    case AaveTypes.EventKind.ProposalCreated: {
-      return [AaveTypes.EntityKind.Proposal, EntityEventKind.Create];
-    }
-    case AaveTypes.EventKind.VoteEmitted: {
-      return [AaveTypes.EntityKind.Proposal, EntityEventKind.Vote];
-    }
-    case AaveTypes.EventKind.ProposalQueued: {
-      return [AaveTypes.EntityKind.Proposal, EntityEventKind.Update];
-    }
-    case AaveTypes.EventKind.ProposalExecuted:
-    case AaveTypes.EventKind.ProposalCanceled: {
-      return [AaveTypes.EntityKind.Proposal, EntityEventKind.Complete];
-    }
-
-    // SUBSTRATE
-    // Democracy Events
-    case SubstrateTypes.EventKind.DemocracyProposed: {
-      return [
-        SubstrateTypes.EntityKind.DemocracyProposal,
-        EntityEventKind.Create,
-      ];
-    }
-    case SubstrateTypes.EventKind.DemocracyTabled: {
-      return [
-        SubstrateTypes.EntityKind.DemocracyProposal,
-        EntityEventKind.Complete,
-      ];
-    }
-
-    case SubstrateTypes.EventKind.DemocracyStarted: {
-      return [
-        SubstrateTypes.EntityKind.DemocracyReferendum,
-        EntityEventKind.Create,
-      ];
-    }
-    case SubstrateTypes.EventKind.DemocracyVoted: {
-      return [
-        SubstrateTypes.EntityKind.DemocracyReferendum,
-        EntityEventKind.Vote,
-      ];
-    }
-    case SubstrateTypes.EventKind.DemocracyPassed: {
-      return [
-        SubstrateTypes.EntityKind.DemocracyReferendum,
-        EntityEventKind.Update,
-      ];
-    }
-    case SubstrateTypes.EventKind.DemocracyNotPassed:
-    case SubstrateTypes.EventKind.DemocracyCancelled:
-    case SubstrateTypes.EventKind.DemocracyExecuted: {
-      return [
-        SubstrateTypes.EntityKind.DemocracyReferendum,
-        EntityEventKind.Complete,
-      ];
-    }
-
-    // Preimage Events
-    case SubstrateTypes.EventKind.PreimageNoted: {
-      return [
-        SubstrateTypes.EntityKind.DemocracyPreimage,
-        EntityEventKind.Create,
-      ];
-    }
-    case SubstrateTypes.EventKind.PreimageUsed:
-    case SubstrateTypes.EventKind.PreimageInvalid:
-    case SubstrateTypes.EventKind.PreimageReaped: {
-      return [
-        SubstrateTypes.EntityKind.DemocracyPreimage,
-        EntityEventKind.Complete,
-      ];
-    }
-
-    // Tip Events
-    case SubstrateTypes.EventKind.NewTip: {
-      return [SubstrateTypes.EntityKind.TipProposal, EntityEventKind.Create];
-    }
-    case SubstrateTypes.EventKind.TipVoted:
-    case SubstrateTypes.EventKind.TipClosing: {
-      return [SubstrateTypes.EntityKind.TipProposal, EntityEventKind.Update];
-    }
-    case SubstrateTypes.EventKind.TipClosed:
-    case SubstrateTypes.EventKind.TipRetracted:
-    case SubstrateTypes.EventKind.TipSlashed: {
-      return [SubstrateTypes.EntityKind.TipProposal, EntityEventKind.Complete];
-    }
-
-    // Treasury Events
-    case SubstrateTypes.EventKind.TreasuryProposed: {
-      return [
-        SubstrateTypes.EntityKind.TreasuryProposal,
-        EntityEventKind.Create,
-      ];
-    }
-    case SubstrateTypes.EventKind.TreasuryRejected:
-    case SubstrateTypes.EventKind.TreasuryAwarded: {
-      return [
-        SubstrateTypes.EntityKind.TreasuryProposal,
-        EntityEventKind.Complete,
-      ];
-    }
-
-    // Bounty Events
-    case SubstrateTypes.EventKind.TreasuryBountyProposed: {
-      return [SubstrateTypes.EntityKind.TreasuryBounty, EntityEventKind.Create];
-    }
-    case SubstrateTypes.EventKind.TreasuryBountyAwarded: {
-      return [SubstrateTypes.EntityKind.TreasuryBounty, EntityEventKind.Update];
-    }
-    case SubstrateTypes.EventKind.TreasuryBountyBecameActive: {
-      return [SubstrateTypes.EntityKind.TreasuryBounty, EntityEventKind.Update];
-    }
-    case SubstrateTypes.EventKind.TreasuryBountyCanceled: {
-      return [
-        SubstrateTypes.EntityKind.TreasuryBounty,
-        EntityEventKind.Complete,
-      ];
-    }
-    case SubstrateTypes.EventKind.TreasuryBountyClaimed: {
-      return [
-        SubstrateTypes.EntityKind.TreasuryBounty,
-        EntityEventKind.Complete,
-      ];
-    }
-    case SubstrateTypes.EventKind.TreasuryBountyExtended: {
-      return [SubstrateTypes.EntityKind.TreasuryBounty, EntityEventKind.Update];
-    }
-    case SubstrateTypes.EventKind.TreasuryBountyRejected: {
-      return [
-        SubstrateTypes.EntityKind.TreasuryBounty,
-        EntityEventKind.Complete,
-      ];
-    }
-
-    // Collective Events
-    case SubstrateTypes.EventKind.CollectiveProposed: {
-      return [
-        SubstrateTypes.EntityKind.CollectiveProposal,
-        EntityEventKind.Create,
-      ];
-    }
-    case SubstrateTypes.EventKind.CollectiveVoted: {
-      return [
-        SubstrateTypes.EntityKind.CollectiveProposal,
-        EntityEventKind.Vote,
-      ];
-    }
-    case SubstrateTypes.EventKind.CollectiveApproved: {
-      return [
-        SubstrateTypes.EntityKind.CollectiveProposal,
-        EntityEventKind.Update,
-      ];
-    }
-    case SubstrateTypes.EventKind.CollectiveDisapproved:
-    case SubstrateTypes.EventKind.CollectiveExecuted: {
-      return [
-        SubstrateTypes.EntityKind.CollectiveProposal,
-        EntityEventKind.Complete,
-      ];
-    }
-
-    // Signaling Events
-    case SubstrateTypes.EventKind.SignalingNewProposal: {
-      return [
-        SubstrateTypes.EntityKind.SignalingProposal,
-        EntityEventKind.Create,
-      ];
-    }
-    case SubstrateTypes.EventKind.SignalingCommitStarted:
-    case SubstrateTypes.EventKind.SignalingVotingStarted: {
-      return [
-        SubstrateTypes.EntityKind.SignalingProposal,
-        EntityEventKind.Update,
-      ];
-    }
-    case SubstrateTypes.EventKind.SignalingVotingCompleted: {
-      return [
-        SubstrateTypes.EntityKind.SignalingProposal,
-        EntityEventKind.Complete,
-      ];
-    }
-    default: {
-      return null;
+  if (network === SupportedNetwork.Moloch) {
+    switch (event) {
+      case MolochTypes.EventKind.SubmitProposal: {
+        return [MolochTypes.EntityKind.Proposal, EntityEventKind.Create];
+      }
+      case MolochTypes.EventKind.SubmitVote: {
+        return [MolochTypes.EntityKind.Proposal, EntityEventKind.Vote];
+      }
+      case MolochTypes.EventKind.ProcessProposal: {
+        return [MolochTypes.EntityKind.Proposal, EntityEventKind.Complete];
+      }
+      case MolochTypes.EventKind.Abort: {
+        return [MolochTypes.EntityKind.Proposal, EntityEventKind.Complete];
+      }
+      default:
+        return null;
     }
   }
+  if (network === SupportedNetwork.Compound) {
+    switch (event) {
+      case CompoundTypes.EventKind.ProposalCanceled: {
+        return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Complete];
+      }
+      case CompoundTypes.EventKind.ProposalCreated: {
+        return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Create];
+      }
+      case CompoundTypes.EventKind.ProposalExecuted: {
+        return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Complete];
+      }
+      case CompoundTypes.EventKind.ProposalQueued: {
+        return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Update];
+      }
+      case CompoundTypes.EventKind.VoteCast: {
+        return [CompoundTypes.EntityKind.Proposal, EntityEventKind.Vote];
+      }
+      default:
+        return null;
+    }
+  }
+  if (network === SupportedNetwork.Aave) {
+    switch (event) {
+      case AaveTypes.EventKind.ProposalCreated: {
+        return [AaveTypes.EntityKind.Proposal, EntityEventKind.Create];
+      }
+      case AaveTypes.EventKind.VoteEmitted: {
+        return [AaveTypes.EntityKind.Proposal, EntityEventKind.Vote];
+      }
+      case AaveTypes.EventKind.ProposalQueued: {
+        return [AaveTypes.EntityKind.Proposal, EntityEventKind.Update];
+      }
+      case AaveTypes.EventKind.ProposalExecuted:
+      case AaveTypes.EventKind.ProposalCanceled: {
+        return [AaveTypes.EntityKind.Proposal, EntityEventKind.Complete];
+      }
+      default:
+        return null;
+    }
+  }
+  if (network === SupportedNetwork.Substrate) {
+    switch (event) {
+      // SUBSTRATE
+      // Democracy Events
+      case SubstrateTypes.EventKind.DemocracyProposed: {
+        return [
+          SubstrateTypes.EntityKind.DemocracyProposal,
+          EntityEventKind.Create,
+        ];
+      }
+      case SubstrateTypes.EventKind.DemocracyTabled: {
+        return [
+          SubstrateTypes.EntityKind.DemocracyProposal,
+          EntityEventKind.Complete,
+        ];
+      }
+
+      case SubstrateTypes.EventKind.DemocracyStarted: {
+        return [
+          SubstrateTypes.EntityKind.DemocracyReferendum,
+          EntityEventKind.Create,
+        ];
+      }
+      case SubstrateTypes.EventKind.DemocracyVoted: {
+        return [
+          SubstrateTypes.EntityKind.DemocracyReferendum,
+          EntityEventKind.Vote,
+        ];
+      }
+      case SubstrateTypes.EventKind.DemocracyPassed: {
+        return [
+          SubstrateTypes.EntityKind.DemocracyReferendum,
+          EntityEventKind.Update,
+        ];
+      }
+      case SubstrateTypes.EventKind.DemocracyNotPassed:
+      case SubstrateTypes.EventKind.DemocracyCancelled:
+      case SubstrateTypes.EventKind.DemocracyExecuted: {
+        return [
+          SubstrateTypes.EntityKind.DemocracyReferendum,
+          EntityEventKind.Complete,
+        ];
+      }
+
+      // Preimage Events
+      case SubstrateTypes.EventKind.PreimageNoted: {
+        return [
+          SubstrateTypes.EntityKind.DemocracyPreimage,
+          EntityEventKind.Create,
+        ];
+      }
+      case SubstrateTypes.EventKind.PreimageUsed:
+      case SubstrateTypes.EventKind.PreimageInvalid:
+      case SubstrateTypes.EventKind.PreimageReaped: {
+        return [
+          SubstrateTypes.EntityKind.DemocracyPreimage,
+          EntityEventKind.Complete,
+        ];
+      }
+
+      // Tip Events
+      case SubstrateTypes.EventKind.NewTip: {
+        return [SubstrateTypes.EntityKind.TipProposal, EntityEventKind.Create];
+      }
+      case SubstrateTypes.EventKind.TipVoted:
+      case SubstrateTypes.EventKind.TipClosing: {
+        return [SubstrateTypes.EntityKind.TipProposal, EntityEventKind.Update];
+      }
+      case SubstrateTypes.EventKind.TipClosed:
+      case SubstrateTypes.EventKind.TipRetracted:
+      case SubstrateTypes.EventKind.TipSlashed: {
+        return [
+          SubstrateTypes.EntityKind.TipProposal,
+          EntityEventKind.Complete,
+        ];
+      }
+
+      // Treasury Events
+      case SubstrateTypes.EventKind.TreasuryProposed: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryProposal,
+          EntityEventKind.Create,
+        ];
+      }
+      case SubstrateTypes.EventKind.TreasuryRejected:
+      case SubstrateTypes.EventKind.TreasuryAwarded: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryProposal,
+          EntityEventKind.Complete,
+        ];
+      }
+
+      // Bounty Events
+      case SubstrateTypes.EventKind.TreasuryBountyProposed: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryBounty,
+          EntityEventKind.Create,
+        ];
+      }
+      case SubstrateTypes.EventKind.TreasuryBountyAwarded: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryBounty,
+          EntityEventKind.Update,
+        ];
+      }
+      case SubstrateTypes.EventKind.TreasuryBountyBecameActive: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryBounty,
+          EntityEventKind.Update,
+        ];
+      }
+      case SubstrateTypes.EventKind.TreasuryBountyCanceled: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryBounty,
+          EntityEventKind.Complete,
+        ];
+      }
+      case SubstrateTypes.EventKind.TreasuryBountyClaimed: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryBounty,
+          EntityEventKind.Complete,
+        ];
+      }
+      case SubstrateTypes.EventKind.TreasuryBountyExtended: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryBounty,
+          EntityEventKind.Update,
+        ];
+      }
+      case SubstrateTypes.EventKind.TreasuryBountyRejected: {
+        return [
+          SubstrateTypes.EntityKind.TreasuryBounty,
+          EntityEventKind.Complete,
+        ];
+      }
+
+      // Collective Events
+      case SubstrateTypes.EventKind.CollectiveProposed: {
+        return [
+          SubstrateTypes.EntityKind.CollectiveProposal,
+          EntityEventKind.Create,
+        ];
+      }
+      case SubstrateTypes.EventKind.CollectiveVoted: {
+        return [
+          SubstrateTypes.EntityKind.CollectiveProposal,
+          EntityEventKind.Vote,
+        ];
+      }
+      case SubstrateTypes.EventKind.CollectiveApproved: {
+        return [
+          SubstrateTypes.EntityKind.CollectiveProposal,
+          EntityEventKind.Update,
+        ];
+      }
+      case SubstrateTypes.EventKind.CollectiveDisapproved:
+      case SubstrateTypes.EventKind.CollectiveExecuted: {
+        return [
+          SubstrateTypes.EntityKind.CollectiveProposal,
+          EntityEventKind.Complete,
+        ];
+      }
+
+      // Signaling Events
+      case SubstrateTypes.EventKind.SignalingNewProposal: {
+        return [
+          SubstrateTypes.EntityKind.SignalingProposal,
+          EntityEventKind.Create,
+        ];
+      }
+      case SubstrateTypes.EventKind.SignalingCommitStarted:
+      case SubstrateTypes.EventKind.SignalingVotingStarted: {
+        return [
+          SubstrateTypes.EntityKind.SignalingProposal,
+          EntityEventKind.Update,
+        ];
+      }
+      case SubstrateTypes.EventKind.SignalingVotingCompleted: {
+        return [
+          SubstrateTypes.EntityKind.SignalingProposal,
+          EntityEventKind.Complete,
+        ];
+      }
+      default: {
+        return null;
+      }
+    }
+  }
+  return null;
 }
 
 export function isEntityCompleted(entityEvents: CWEvent[]): boolean {
-  return entityEvents.some(({ data: { kind } }) => {
-    const entityData = eventToEntity(kind);
+  return entityEvents.some(({ network, data: { kind } }) => {
+    const entityData = eventToEntity(network, kind);
     return entityData && entityData[1] === EntityEventKind.Complete;
   });
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,23 +1,14 @@
 import {
-  chainSupportedBy,
-  EventSupportingChainT,
   IDisconnectedRange,
   IEventProcessor,
   IEventSubscriber,
   IStorageFetcher,
+  SupportedNetwork,
 } from './interfaces';
-import { EventChains as SubstrateChains } from './chains/substrate/types';
-import {
-  Listener as SubstrateListener,
-  EnricherConfig,
-} from './chains/substrate';
-import { EventChains as MolochChains } from './chains/moloch/types';
+import { Listener as SubstrateListener } from './chains/substrate';
 import { Listener as MolochListener } from './chains/moloch/Listener';
-import { EventChains as CompoundChains } from './chains/compound/types';
 import { Listener as CompoundListener } from './chains/compound/Listener';
-import { EventChains as Erc20Chain } from './chains/erc20/types';
 import { Listener as Erc20Listener } from './chains/erc20';
-import { EventChains as AaveChains } from './chains/aave/types';
 import { Listener as AaveListener } from './chains/aave';
 import { Listener } from './Listener';
 import { factory, formatFilename } from './logging';
@@ -28,10 +19,11 @@ const log = factory.getLogger(formatFilename(__filename));
  * Creates a listener instance and returns it if no error occurs. This function throws on error.
  * @param chain The chain to create a listener for
  * @param options The listener options for the specified chain
- * @param customChainBase Used to override the base system the chain is from if it does not yet exist in EventChains
+ * @param network the listener network to use
  */
 export async function createListener(
   chain: string,
+  network: SupportedNetwork,
   options: {
     address?: string;
     tokenAddresses?: string[];
@@ -45,8 +37,7 @@ export async function createListener(
     url?: string;
     enricherConfig?: any;
     discoverReconnectRange?: (c: string) => Promise<IDisconnectedRange>;
-  },
-  customChainBase?: string
+  }
 ): Promise<
   Listener<
     any,
@@ -64,29 +55,10 @@ export async function createListener(
     any
   >;
 
-  // checks chain compatibility or overrides
-  function basePicker(base: string): boolean {
-    if (customChainBase === base) return true;
-    switch (base) {
-      case 'substrate':
-        return chainSupportedBy(chain, SubstrateChains);
-      case 'moloch':
-        return chainSupportedBy(chain, MolochChains);
-      case 'compound':
-        return chainSupportedBy(chain, CompoundChains);
-      case 'erc20':
-        return chainSupportedBy(chain, Erc20Chain);
-      case 'aave':
-        return chainSupportedBy(chain, AaveChains);
-      default:
-        return false;
-    }
-  }
-
-  if (basePicker('substrate')) {
+  if (network === SupportedNetwork.Substrate) {
     // start a substrate listener
     listener = new SubstrateListener(
-      <EventSupportingChainT>chain,
+      chain,
       options.url,
       options.spec,
       !!options.archival,
@@ -94,12 +66,11 @@ export async function createListener(
       !!options.skipCatchup,
       options.enricherConfig,
       !!options.verbose,
-      !!customChainBase,
       options.discoverReconnectRange
     );
-  } else if (basePicker('moloch')) {
+  } else if (network === SupportedNetwork.Moloch) {
     listener = new MolochListener(
-      <EventSupportingChainT>chain,
+      chain,
       options.MolochContractVersion ? options.MolochContractVersion : 2,
       options.address,
       options.url,
@@ -107,41 +78,35 @@ export async function createListener(
       !!options.verbose,
       options.discoverReconnectRange
     );
-  } else if (basePicker('compound')) {
+  } else if (network === SupportedNetwork.Compound) {
     listener = new CompoundListener(
-      <EventSupportingChainT>chain,
+      chain,
       options.address,
       options.url,
       !!options.skipCatchup,
       !!options.verbose,
       options.discoverReconnectRange
     );
-  } else if (basePicker('erc20')) {
+  } else if (network === SupportedNetwork.ERC20) {
     listener = new Erc20Listener(
-      <EventSupportingChainT>chain,
+      chain,
       options.tokenAddresses || [options.address],
       options.url,
       Array.isArray(options.tokenNames) ? options.tokenNames : undefined,
       options.enricherConfig,
-      !!options.verbose,
-      !!customChainBase
+      !!options.verbose
     );
-  } else if (basePicker('aave')) {
+  } else if (network === SupportedNetwork.Aave) {
     listener = new AaveListener(
-      <EventSupportingChainT>chain,
+      chain,
       options.address,
       options.url,
       !!options.skipCatchup,
       !!options.verbose,
-      !!customChainBase,
       options.discoverReconnectRange
     );
   } else {
-    throw new Error(
-      customChainBase
-        ? `No listener built for ${customChainBase}`
-        : "The given chain's base does not match any built in listener"
-    );
+    throw new Error(`Invalid network: ${network}`);
   }
 
   try {

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,16 +4,77 @@ import {
   IEventSubscriber,
   IStorageFetcher,
   SupportedNetwork,
+  CWEvent,
+  IEventTitle,
+  IEventLabel,
+  IChainEventKind,
 } from './interfaces';
-import { Listener as SubstrateListener } from './chains/substrate';
-import { Listener as MolochListener } from './chains/moloch/Listener';
-import { Listener as CompoundListener } from './chains/compound/Listener';
-import { Listener as Erc20Listener } from './chains/erc20';
-import { Listener as AaveListener } from './chains/aave';
+import {
+  Listener as SubstrateListener,
+  Title as SubstrateTitle,
+  Label as SubstrateLabel,
+} from './chains/substrate';
+import {
+  Listener as MolochListener,
+  Title as MolochTitle,
+  Label as MolochLabel,
+} from './chains/moloch';
+import {
+  Listener as CompoundListener,
+  Title as CompoundTitle,
+  Label as CompoundLabel,
+} from './chains/compound';
+import {
+  Listener as Erc20Listener,
+  Title as Erc20Title,
+  Label as Erc20Label,
+} from './chains/erc20';
+import {
+  Listener as AaveListener,
+  Title as AaveTitle,
+  Label as AaveLabel,
+} from './chains/aave';
 import { Listener } from './Listener';
 import { factory, formatFilename } from './logging';
 
 const log = factory.getLogger(formatFilename(__filename));
+
+export function Title(
+  network: SupportedNetwork,
+  kind: IChainEventKind
+): IEventTitle {
+  switch (network) {
+    case SupportedNetwork.Substrate:
+      return SubstrateTitle(kind);
+    case SupportedNetwork.Aave:
+      return AaveTitle(kind);
+    case SupportedNetwork.Compound:
+      return CompoundTitle(kind);
+    case SupportedNetwork.ERC20:
+      return Erc20Title(kind);
+    case SupportedNetwork.Moloch:
+      return MolochTitle(kind);
+    default:
+      throw new Error(`Invalid network: ${network}`);
+  }
+}
+
+export function Label(chain: string, event: CWEvent): IEventLabel {
+  switch (event.network) {
+    case SupportedNetwork.Substrate:
+      return SubstrateLabel(event.blockNumber, chain, event.data);
+    case SupportedNetwork.Aave:
+      return AaveLabel(event.blockNumber, chain, event.data);
+    case SupportedNetwork.Compound:
+      return CompoundLabel(event.blockNumber, chain, event.data);
+    case SupportedNetwork.ERC20:
+      return Erc20Label(event.blockNumber, chain, event.data);
+    case SupportedNetwork.Moloch:
+      return MolochLabel(event.blockNumber, chain, event.data);
+    default:
+      throw new Error(`Invalid network: ${event.network}`);
+  }
+}
 
 /**
  * Creates a listener instance and returns it if no error occurs. This function throws on error.

--- a/test/integration/moloch.spec.ts
+++ b/test/integration/moloch.spec.ts
@@ -23,7 +23,6 @@ import { subscribeEvents } from '../../src/chains/moloch/subscribeFunc';
 import {
   IEventHandler,
   CWEvent,
-  EventSupportingChainT,
   IDisconnectedRange,
   IChainEventData,
 } from '../../src/interfaces';
@@ -93,7 +92,7 @@ async function setupSubscription(subscribe = true): Promise<ISetupData> {
   const handler = new MolochEventHandler(emitter);
   if (subscribe) {
     await subscribeEvents({
-      chain: 'test' as EventSupportingChainT,
+      chain: 'test',
       api,
       contractVersion: 1,
       handlers: [handler],
@@ -434,7 +433,7 @@ describe('Moloch Event Integration Tests', () => {
       startBlock: 0,
     });
     const subscription = await subscribeEvents({
-      chain: 'test' as EventSupportingChainT,
+      chain: 'test',
       api,
       contractVersion: 1,
       handlers: [handler],

--- a/test/unit/aave/listener.spec.ts
+++ b/test/unit/aave/listener.spec.ts
@@ -9,7 +9,6 @@ import {
   Subscriber,
   Listener,
 } from '../../../src/chains/aave';
-import { EventSupportingChainT } from '../../../src';
 import { networkUrls, contracts } from '../../../scripts/listenerUtils';
 import { TestHandler } from '../../util';
 
@@ -20,17 +19,6 @@ const { assert } = chai;
 describe.skip('Aave listener class tests', () => {
   let listener;
   const handlerEmitter = new events.EventEmitter();
-
-  it('should throw if the chain is not an Aave based contract', () => {
-    try {
-      const _listener = new Listener(
-        'randomChain' as EventSupportingChainT,
-        contracts.aave
-      );
-    } catch (error) {
-      assert(String(error).includes('randomChain'));
-    }
-  });
 
   it('should create an Aave listener', () => {
     listener = new Listener('aave', contracts.aave, null, true, false);

--- a/test/unit/compound/listener.spec.ts
+++ b/test/unit/compound/listener.spec.ts
@@ -9,7 +9,6 @@ import {
   Subscriber,
   Listener,
 } from '../../../src/chains/compound';
-import { EventSupportingChainT } from '../../../src';
 import { networkUrls, contracts } from '../../../scripts/listenerUtils';
 import { TestHandler } from '../../util';
 
@@ -20,17 +19,6 @@ const { assert } = chai;
 describe.skip('Compound listener class tests', () => {
   let listener;
   const handlerEmitter = new events.EventEmitter();
-
-  it('should throw if the chain is not a Compound based chain', () => {
-    try {
-      const _listener = new Listener(
-        'randomChain' as EventSupportingChainT,
-        contracts.marlin
-      );
-    } catch (error) {
-      assert(String(error).includes('randomChain'));
-    }
-  });
 
   it('should create a Compound listener', () => {
     listener = new Listener('marlin', contracts.marlin, null, true, false);

--- a/test/unit/erc20/listener.spec.ts
+++ b/test/unit/erc20/listener.spec.ts
@@ -4,7 +4,6 @@ import * as chai from 'chai';
 import dotenv from 'dotenv';
 
 import { Processor, Subscriber, Listener } from '../../../src/chains/erc20';
-import { EventSupportingChainT } from '../../../src';
 import { networkUrls } from '../../../scripts/listenerUtils';
 import { TestHandler } from '../../util';
 
@@ -20,21 +19,6 @@ const tokenNames = ['USDT', 'USDC'];
 describe.skip('Erc20 listener class tests', () => {
   let listener;
   const handlerEmitter = new events.EventEmitter();
-
-  it('should throw if the chain is not an Aave based contract', () => {
-    try {
-      // eslint-disable-next-line no-new
-      new Listener(
-        'randomChain' as EventSupportingChainT,
-        tokenAddresses,
-        networkUrls.erc20,
-        tokenNames,
-        {}
-      );
-    } catch (error) {
-      assert(String(error).includes('randomChain'));
-    }
-  });
 
   it('should create an Erc20 listener', () => {
     listener = new Listener(

--- a/test/unit/moloch/listener.spec.ts
+++ b/test/unit/moloch/listener.spec.ts
@@ -9,7 +9,6 @@ import {
   Subscriber,
   Listener,
 } from '../../../src/chains/moloch';
-import { EventSupportingChainT } from '../../../src';
 import { networkUrls, contracts } from '../../../scripts/listenerUtils';
 import { TestHandler } from '../../util';
 
@@ -20,14 +19,6 @@ const { assert } = chai;
 describe.skip('Moloch listener class tests', () => {
   let listener;
   const handlerEmitter = new events.EventEmitter();
-
-  it('should throw if the chain is not a moloch chain', () => {
-    try {
-      const _listener = new Listener('randomChain' as EventSupportingChainT);
-    } catch (error) {
-      assert(String(error).includes('randomChain'));
-    }
-  });
 
   it('should create the moloch listener', () => {
     listener = new Listener('moloch');

--- a/test/unit/substrate/listener.spec.ts
+++ b/test/unit/substrate/listener.spec.ts
@@ -10,7 +10,6 @@ import {
   Subscriber,
   Listener,
 } from '../../../src/chains/substrate';
-import { EventSupportingChainT } from '../../../src';
 import { networkUrls } from '../../../scripts/listenerUtils';
 import { TestHandler } from '../../util';
 
@@ -19,14 +18,6 @@ const { assert } = chai;
 describe.skip('Substrate listener class tests', () => {
   let listener;
   const handlerEmitter = new events.EventEmitter();
-
-  it('should throw if the chain is not a substrate chain', () => {
-    try {
-      const _listener = new Listener('randomChain' as EventSupportingChainT);
-    } catch (error) {
-      assert(String(error).includes('randomChain'));
-    }
-  });
 
   it('should create the substrate listener', () => {
     listener = new Listener(


### PR DESCRIPTION
We no longer hardcode a list of supported chains. Instead, we select which chain logic to use based on a SupportedNetwork enum flag, which is now mandatory on the CWEvent type.

The benefit of this is that we no longer need to push a new version of Chain Events to add a new "supported chain" of any type. It also unifies the form of ERC20 handling with the rest of the chains (far fewer special cases necessary).