### PR TITLE
Remove hard dependency on infura/alchemy ETH urls.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonwealth/chain-events",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Listen to various chains for events.",
   "license": "GPL-3.0",
   "files": [

--- a/scripts/listenerUtils.ts
+++ b/scripts/listenerUtils.ts
@@ -17,21 +17,23 @@ export const networkUrls = {
   kulupu: 'ws://rpc.kulupu.corepaper.org/ws',
   stafi: 'wss://scan-rpc.stafi.io/ws',
 
-  moloch: 'wss://mainnet.infura.io/ws',
+  moloch: 'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr',
   'moloch-local': 'ws://127.0.0.1:9545',
 
-  marlin: 'wss://mainnet.infura.io/ws',
+  marlin: 'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr',
   'marlin-local': 'ws://127.0.0.1:9545',
-  uniswap: 'wss://mainnet.infura.io/ws',
-  tribe: 'wss://mainnet.infura.io/ws',
+  uniswap:
+    'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr',
+  tribe: 'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr',
 
-  aave: 'wss://mainnet.infura.io/ws',
+  aave: 'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr',
   'aave-local': 'ws://127.0.0.1:9545',
-  'dydx-ropsten': 'wss://ropsten.infura.io/ws',
-  dydx: 'wss://mainnet.infura.io/ws',
+  'dydx-ropsten':
+    'wss://eth-ropsten.alchemyapi.io/v2/2xXT2xx5AvA3GFTev3j_nB9LzWdmxPk7',
+  dydx: 'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr',
   frax: 'ws://localhost:8545',
 
-  erc20: 'wss://mainnet.infura.io/ws',
+  erc20: 'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr',
 } as const;
 
 export const networkSpecs: { [chain: string]: RegisteredTypes } = {

--- a/src/eth.ts
+++ b/src/eth.ts
@@ -9,56 +9,26 @@ export async function createProvider(
   chain?: string
 ): Promise<providers.Web3Provider> {
   const log = factory.getLogger(addPrefix(__filename, [network, chain]));
-
-  if (
-    !ethNetworkUrl.includes('alchemy') &&
-    !ethNetworkUrl.includes('infura') &&
-    !ethNetworkUrl.includes('localhost') &&
-    !ethNetworkUrl.includes('127.0.0.1')
-  )
-    throw new Error('Must use Alchemy or Infura Ethereum API');
-  if (process && process.env) {
-    // only rewrite URL for alchemy/infura, preserve for localhost
-    if (ethNetworkUrl.includes('alchemy') || ethNetworkUrl.includes('infura')) {
-      // TODO: alchemy keys are different per network, so we need to ensure we have the correct
-      //   keys for arbitrary networks
-      let ALCHEMY_API_KEY;
-      if (ethNetworkUrl.includes('ropsten')) {
-        ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY_ROPSTEN;
-        ethNetworkUrl = `wss://eth-ropsten.alchemyapi.io/v2/${ALCHEMY_API_KEY}`;
-      } else if (ethNetworkUrl.includes('mainnet')) {
-        ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY;
-        ethNetworkUrl = `wss://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_API_KEY}`;
-      } else {
-        throw new Error('Must be on either ropsten or mainnet');
-      }
-      if (!ALCHEMY_API_KEY) {
-        throw new Error('Alchemy API key not found, check your .env file');
-      }
-    }
-
-    try {
-      const web3Provider = new Web3.providers.WebsocketProvider(ethNetworkUrl, {
-        reconnect: {
-          auto: true,
-          delay: 5000,
-          maxAttempts: 10,
-          onTimeout: true,
-        },
-      });
-      const provider = new providers.Web3Provider(web3Provider);
-      // 12s minute polling interval (default is 4s)
-      provider.pollingInterval = 12000;
-      const data = await provider.getBlock('latest');
-      if (!data)
-        throw new Error('A connection to Alchemy could not be established.');
-      return provider;
-    } catch (error) {
-      log.error(`Failed to connect on ${ethNetworkUrl}`);
-      log.error(`Check your ALCHEMY_API_KEY: ${error.message}`);
-      throw error;
-    }
-  } else {
-    throw new Error('must use nodejs to connect to Alchemy provider!');
+  try {
+    const web3Provider = new Web3.providers.WebsocketProvider(ethNetworkUrl, {
+      reconnect: {
+        auto: true,
+        delay: 5000,
+        maxAttempts: 10,
+        onTimeout: true,
+      },
+    });
+    const provider = new providers.Web3Provider(web3Provider);
+    // 12s minute polling interval (default is 4s)
+    provider.pollingInterval = 12000;
+    const data = await provider.getBlock('latest');
+    if (!data)
+      throw new Error(
+        `A connection to ${ethNetworkUrl} could not be established.`
+      );
+    return provider;
+  } catch (error) {
+    log.error(`Failed to connect on ${ethNetworkUrl}: ${error.message}`);
+    throw error;
   }
 }


### PR DESCRIPTION
## Description
No longer rewrite alchemy/infura keys to use the key -- we now just use whatever is provided. Deprecates the infura/alchemy environment variables as well.

DO NOT USE until Commonwealth has been changed to provide URLs with API keys in them already!

## Motivation and Context
Alchemy has its own origin whitelist, so we have no need to guard our API keys behind an environment variable. We just take what's given.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Built and tested using the listener.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
