### PR TITLE
Erc20 Approve events chain augmentation

### DIFF
--- a/scripts/listenerV2.ts
+++ b/scripts/listenerV2.ts
@@ -36,20 +36,65 @@ const { argv } = yargs.options({
   },
 });
 
+const shortcuts = {
+  substrate: {
+    chain: 'polkadot',
+    network: SupportedNetwork.Substrate,
+    url: networkUrls.polkadot,
+    spec: networkSpecs.polkadot,
+    enricherConfig: {
+      balanceTransferThreshold: 500_000,
+    },
+  },
+  erc20: {
+    chain: 'erc20',
+    network: SupportedNetwork.ERC20,
+    url: networkUrls.erc20,
+    tokenAddresses: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
+    tokenNames: ['usd-coin'],
+  },
+  compound: {
+    chain: 'marlin',
+    network: SupportedNetwork.Compound,
+    url: networkUrls.marlin,
+    address: contracts.marlin,
+  },
+  aave: {
+    chain: 'dydx',
+    network: SupportedNetwork.Aave,
+    url: networkUrls.dydx,
+    address: contracts.dydx,
+  },
+  moloch: {
+    chain: 'moloch',
+    network: SupportedNetwork.Moloch,
+    url: networkUrls.moloch,
+    address: contracts.moloch,
+  },
+};
+
 async function main(): Promise<any> {
   let listener;
+  let sc;
+  if (argv.network && !argv.chain) sc = shortcuts[argv.network];
   try {
-    listener = await createListener(argv.chain || 'dummyChain', argv.network, {
-      url: argv.url || networkUrls[argv.chain],
-      address: argv.contractAddress || contracts[argv.chain],
-      tokenAddresses: [argv.contractAddress],
-      tokenNames: [argv.tokenName],
-      verbose: false,
-      spec: <any>networkSpecs[argv.chain],
-      enricherConfig: {
-        balanceTransferThreshold: 500_000,
-      },
-    });
+    listener = await createListener(
+      argv.chain || sc.chain || 'dummyChain',
+      argv.network || sc.network,
+      {
+        url: argv.url || sc.url || networkUrls[argv.chain],
+        address: argv.contractAddress || sc.address || contracts[argv.chain],
+        tokenAddresses: argv.contractAddress
+          ? [argv.contractAddress]
+          : sc.tokenAddresses,
+        tokenNames: argv.tokenName ? [argv.tokenName] : sc.tokenNames,
+        verbose: false,
+        spec: sc.spec || <any>networkSpecs[argv.chain],
+        enricherConfig: sc.enricherConfig || {
+          balanceTransferThreshold: 500_000,
+        },
+      }
+    );
 
     listener.eventHandlers.logger = {
       handler: new LoggingHandler(),

--- a/src/chains/erc20/filters/enricher.ts
+++ b/src/chains/erc20/filters/enricher.ts
@@ -61,6 +61,7 @@ export async function Enrich(
       const excludeAddresses = [owner.toString(), spender.toString()];
 
       return {
+        chain: <never>tokenName,
         blockNumber,
         excludeAddresses,
         network: SupportedNetwork.ERC20,

--- a/src/chains/erc20/filters/enricher.ts
+++ b/src/chains/erc20/filters/enricher.ts
@@ -61,7 +61,6 @@ export async function Enrich(
       const excludeAddresses = [owner.toString(), spender.toString()];
 
       return {
-        chain: <never>tokenName,
         blockNumber,
         excludeAddresses,
         network: SupportedNetwork.ERC20,
@@ -96,7 +95,6 @@ export async function Enrich(
       const excludeAddresses = [from.toString(), to.toString()];
 
       return {
-        chain: <never>tokenName,
         blockNumber,
         excludeAddresses,
         network: SupportedNetwork.ERC20,

--- a/src/chains/erc20/processor.ts
+++ b/src/chains/erc20/processor.ts
@@ -40,6 +40,7 @@ export class Processor extends IEventProcessor<IErc20Contracts, RawEvent> {
         event,
         this._enricherConfig
       );
+      cwEvent.chain = tokenName;
       return cwEvent ? [cwEvent] : [];
     } catch (e) {
       log.error(

--- a/src/chains/erc20/subscriber.ts
+++ b/src/chains/erc20/subscriber.ts
@@ -31,9 +31,11 @@ export class Subscriber extends IEventSubscriber<IErc20Contracts, RawEvent> {
       const log = factory.getLogger(
         addPrefix(__filename, [SupportedNetwork.ERC20, tokenName])
       );
-      const logStr = `[${SupportedNetwork.ERC20}::${tokenName}]: Received ${
-        this._name
-      } event: ${JSON.stringify(event, null, 2)}.`;
+      const logStr = `Received ${this._name} event: ${JSON.stringify(
+        event,
+        null,
+        2
+      )}.`;
       // eslint-disable-next-line no-unused-expressions
       this._verbose ? log.info(logStr) : log.trace(logStr);
       cb(event, tokenName);


### PR DESCRIPTION
Tiny PR to fix adding the token name to erc20 events. Approve events were not being augmented with a token name which resulted in `storage.ts` errors in `chainEventsConsumer.ts`.

PR includes a small logging fix as well as a shortcut for `listenerV2.ts`. You can now simply specify a network like 
`yarn listenV2 erc20` and it will run a listener for a default token or chain. Skips having to specify a chain in all cases and in the case of erc20 having to specify a token address and name (mostly useful for erc20).

Defaults:
substrate -> polkadot
erc20 -> usd-coin
moloch -> moloch
compound -> marlin
aave -> dydx