### PR TITLE
Add listening/processing of ERC721 events.

### DIFF
--- a/src/chains/erc20/subscriber.ts
+++ b/src/chains/erc20/subscriber.ts
@@ -1,5 +1,5 @@
 /**
- * Fetches events from Compound contract in real time.
+ * Fetches events from ERC20 contract in real time.
  */
 import { Listener } from '@ethersproject/providers';
 import sleep from 'sleep-promise';

--- a/src/chains/erc721/Listener.ts
+++ b/src/chains/erc721/Listener.ts
@@ -1,0 +1,131 @@
+import { CWEvent, SupportedNetwork } from '../../interfaces';
+import { Listener as BaseListener } from '../../Listener';
+import { addPrefix, factory } from '../../logging';
+
+import {
+  EventKind,
+  IErc721Contracts,
+  ListenerOptions as Erc721ListenerOptions,
+  RawEvent,
+} from './types';
+import { createApi } from './subscribeFunc';
+import { Processor } from './processor';
+import { Subscriber } from './subscriber';
+
+export class Listener extends BaseListener<
+  IErc721Contracts,
+  never,
+  Processor,
+  Subscriber,
+  EventKind
+> {
+  private readonly _options: Erc721ListenerOptions;
+
+  protected readonly log;
+
+  constructor(
+    chain: string,
+    tokenAddresses: string[],
+    url?: string,
+    tokenNames?: string[],
+    verbose?: boolean
+  ) {
+    super(SupportedNetwork.ERC721, chain, verbose);
+
+    this.log = factory.getLogger(
+      addPrefix(__filename, [SupportedNetwork.ERC721])
+    );
+
+    this._options = {
+      url,
+      tokenAddresses,
+      tokenNames,
+    };
+
+    this._subscribed = false;
+  }
+
+  public async init(): Promise<void> {
+    try {
+      this._api = await createApi(
+        this._options.url,
+        this._options.tokenAddresses,
+        this._options.tokenNames,
+        10000
+      );
+    } catch (error) {
+      this.log.error('Fatal error occurred while starting the API');
+      throw error;
+    }
+
+    try {
+      this._processor = new Processor(this._api);
+      this._subscriber = new Subscriber(this._api, this._chain, this._verbose);
+    } catch (error) {
+      this.log.error(
+        'Fatal error occurred while starting the Processor and Subscriber'
+      );
+      throw error;
+    }
+  }
+
+  public async subscribe(): Promise<void> {
+    if (!this._subscriber) {
+      this.log.info("Subscriber isn't initialized. Please run init() first!");
+      return;
+    }
+
+    try {
+      this.log.info(
+        `Subscribing to the following token(s): ${
+          this.options.tokenNames || '[token names not given!]'
+        }, on url ${this._options.url}`
+      );
+      await this._subscriber.subscribe(this.processBlock.bind(this));
+      this._subscribed = true;
+    } catch (error) {
+      this.log.error(`Subscription error: ${error.message}`);
+    }
+  }
+
+  // override handleEvent to stop the chain from being added to event data
+  // since the chain/token name is added to event data in the subscriber.ts
+  // (since there are multiple tokens)
+  protected async handleEvent(event: CWEvent): Promise<void> {
+    let prevResult;
+
+    // eslint-disable-next-line guard-for-in
+    for (const key in this.eventHandlers) {
+      const eventHandler = this.eventHandlers[key];
+      if (
+        this.globalExcludedEvents.includes(event.data.kind as EventKind) ||
+        eventHandler.excludedEvents?.includes(event.data.kind as EventKind)
+      )
+        // eslint-disable-next-line no-continue
+        continue;
+
+      try {
+        prevResult = await eventHandler.handler.handle(event, prevResult);
+      } catch (err) {
+        this.log.error(`Event handle failure: ${err.message}`);
+        break;
+      }
+    }
+  }
+
+  protected async processBlock(
+    event: RawEvent,
+    tokenName?: string
+  ): Promise<void> {
+    const cwEvents: CWEvent[] = await this._processor.process(event, tokenName);
+
+    // process events in sequence
+    for (const e of cwEvents) {
+      await this.handleEvent(e as CWEvent);
+    }
+  }
+
+  public get options(): Erc721ListenerOptions {
+    return this._options;
+  }
+}

--- a/src/chains/erc721/filters/enricher.ts
+++ b/src/chains/erc721/filters/enricher.ts
@@ -1,0 +1,101 @@
+import BN from 'bn.js';
+
+import { CWEvent, SupportedNetwork } from '../../../interfaces';
+import { TypedEventFilter } from '../../../contractTypes/commons';
+import { ERC721 } from '../../../contractTypes';
+import { EventKind, RawEvent, IEventData, IErc721Contracts } from '../types';
+
+/**
+ * This is an "enricher" function, whose goal is to augment the initial event data
+ * received from the "system.events" query with additional useful information, as
+ * described in the event's interface in our "types.ts" file.
+ *
+ * Once fetched, the function marshalls the event data and the additional information
+ * into the interface, and returns a fully-formed event, ready for database storage.
+ */
+
+type GetEventArgs<T> = T extends TypedEventFilter<unknown, infer Y> ? Y : never;
+type GetArgType<Name extends keyof ERC721['filters']> = GetEventArgs<
+  ReturnType<ERC721['filters'][Name]>
+>;
+
+export async function Enrich(
+  api: IErc721Contracts,
+  blockNumber: number,
+  kind: EventKind,
+  rawData: RawEvent
+): Promise<CWEvent<IEventData>> {
+  switch (kind) {
+    case EventKind.Approval: {
+      const { owner, approved, tokenId } = rawData.args as GetArgType<
+        'Approval'
+      >;
+      const contractAddress = rawData.address;
+
+      // should not notify sender or recipient
+      const excludeAddresses = [owner.toString(), approved.toString()];
+
+      return {
+        blockNumber,
+        excludeAddresses,
+        network: SupportedNetwork.ERC721,
+        data: {
+          kind,
+          owner,
+          approved,
+          tokenId: tokenId.toString(),
+          contractAddress,
+        },
+      };
+    }
+    case EventKind.ApprovalForAll: {
+      const { owner, operator, approved } = rawData.args as GetArgType<
+        'ApprovalForAll'
+      >;
+      const contractAddress = rawData.address;
+
+      // should not notify sender or recipient
+      const excludeAddresses = [owner.toString(), operator.toString()];
+
+      return {
+        blockNumber,
+        excludeAddresses,
+        network: SupportedNetwork.ERC721,
+        data: {
+          kind,
+          owner,
+          operator,
+          approved,
+          contractAddress,
+        },
+      };
+    }
+    case EventKind.Transfer: {
+      const { from, to, tokenId } = rawData.args as GetArgType<'Transfer'>;
+      const contractAddress = rawData.address;
+
+      // no need to explicitly filter transfers of zero tokens, as
+      // this would just throw with ERC721.
+
+      // should not notify sender or recipient
+      const excludeAddresses = [from.toString(), to.toString()];
+
+      return {
+        blockNumber,
+        excludeAddresses,
+        network: SupportedNetwork.ERC721,
+        data: {
+          kind,
+          from,
+          to,
+          tokenId: tokenId.toString(),
+          contractAddress,
+        },
+      };
+    }
+
+    default: {
+      throw new Error(`Unknown event kind: ${kind}`);
+    }
+  }
+}

--- a/src/chains/erc721/filters/labeler.ts
+++ b/src/chains/erc721/filters/labeler.ts
@@ -1,0 +1,74 @@
+import BN from 'bn.js';
+
+import {
+  LabelerFilter,
+  IEventLabel,
+  SupportedNetwork,
+} from '../../../interfaces';
+import { IEventData, EventKind } from '../types';
+
+function fmtAddr(addr: string) {
+  if (!addr) return '';
+  if (addr.length < 16) return addr;
+  return `${addr.slice(0, 7)}…${addr.slice(addr.length - 3)}`;
+}
+
+/**
+ * This a labeler function, which takes event data and describes it in "plain english",
+ * such that we can display a notification regarding its contents.
+ */
+export const Label: LabelerFilter = (
+  blockNumber: number,
+  chainId: string,
+  data: IEventData
+): IEventLabel => {
+  switch (data.kind) {
+    case EventKind.Approval: {
+      // check to see if owner disapproves all addresses
+      let label = '';
+      if (!new BN(data.approved, 10).isZero()) {
+        label = `Owner ${fmtAddr(data.owner)} approved ${fmtAddr(data.approved)}
+        to transfer token ${data.tokenId}.`;
+      } else {
+        label = `Owner ${fmtAddr(data.owner)} disapproved any address
+          previously able to transfer token ${data.tokenId}.`;
+      }
+      return {
+        heading: 'ApprovalForAll',
+        label,
+      };
+    }
+    case EventKind.ApprovalForAll: {
+      // check to see if owner disapproves all addresses
+      let label = '';
+      if (data.approved) {
+        label = `Owner ${fmtAddr(data.owner)} approved operator ${fmtAddr(
+          data.operator
+        )}
+        to transfer all of their tokens.`;
+      } else {
+        label = `Owner ${fmtAddr(data.owner)} has disapproved ${fmtAddr(
+          data.operator
+        )}
+          from transferring any of their tokens.`;
+      }
+      return {
+        heading: 'Approval For All',
+        label,
+      };
+    }
+    case EventKind.Transfer:
+      return {
+        heading: 'Transfer',
+        label: `Transfer of ${data.tokenId} on ${chainId} from ${data.from} to ${data.to}.`,
+      };
+    default: {
+      // ensure exhaustive matching -- gives ts error if missing cases
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _exhaustiveMatch: never = data;
+      throw new Error(
+        `[${SupportedNetwork.ERC721}::${chainId}]: Unknown event type`
+      );
+    }
+  }
+};

--- a/src/chains/erc721/filters/titler.ts
+++ b/src/chains/erc721/filters/titler.ts
@@ -1,0 +1,39 @@
+import {
+  IEventTitle,
+  SupportedNetwork,
+  TitlerFilter,
+} from '../../../interfaces';
+import { EventKind } from '../types';
+
+/**
+ * This a titler function, not to be confused with the labeler -- it takes a particular
+ * kind of event, and returns a "plain english" description of that type. This is used
+ * on the client to present a list of subscriptions that a user might want to subscribe to.
+ */
+export const Title: TitlerFilter = (kind: EventKind): IEventTitle => {
+  switch (kind) {
+    case EventKind.Approval:
+      return {
+        title: 'Delegation Approved',
+        description: 'One account delegated a token to another.',
+      };
+    case EventKind.ApprovalForAll:
+      return {
+        title: 'Full Delegation Approved',
+        description: 'One account delegated all of its tokens to another.',
+      };
+    case EventKind.Transfer:
+      return {
+        title: 'Tokens Transferred',
+        description: 'Tokens have been transferred.',
+      };
+    default: {
+      // ensure exhaustive matching -- gives ts error if missing cases
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _exhaustiveMatch: never = kind;
+      throw new Error(
+        `[${SupportedNetwork.ERC721}]: Unknown event type: ${kind}`
+      );
+    }
+  }
+};

--- a/src/chains/erc721/filters/type_parser.ts
+++ b/src/chains/erc721/filters/type_parser.ts
@@ -1,0 +1,26 @@
+import { EventKind } from '../types';
+import { addPrefix, factory } from '../../../logging';
+import { SupportedNetwork } from '../../../interfaces';
+
+/**
+ * This is the Type Parser function, which takes a raw Event
+ * and determines which of our local event kinds it belongs to.
+ */
+export function ParseType(name: string, tokenName?: string): EventKind | null {
+  const log = factory.getLogger(
+    addPrefix(__filename, [SupportedNetwork.ERC721, tokenName])
+  );
+  switch (name) {
+    // ERC721 Events
+    case 'Approval':
+      return EventKind.Approval;
+    case 'ApprovalForAll':
+      return EventKind.ApprovalForAll;
+    case 'Transfer':
+      return EventKind.Transfer;
+    default: {
+      log.info(`Unknown event name: ${name}!`);
+      return null;
+    }
+  }
+}

--- a/src/chains/erc721/index.ts
+++ b/src/chains/erc721/index.ts
@@ -1,0 +1,10 @@
+export * as Types from './types';
+export * from './subscribeFunc';
+export * from './subscriber';
+export * from './processor';
+export * from './Listener';
+
+export * from './filters/enricher';
+export * from './filters/labeler';
+export * from './filters/titler';
+export * from './filters/type_parser';

--- a/src/chains/erc721/processor.ts
+++ b/src/chains/erc721/processor.ts
@@ -1,0 +1,43 @@
+/**
+ * Processes ERC721 events.
+ */
+import { IEventProcessor, CWEvent, SupportedNetwork } from '../../interfaces';
+import { addPrefix, factory } from '../../logging';
+
+import { ParseType } from './filters/type_parser';
+import { Enrich } from './filters/enricher';
+import { IEventData, RawEvent, IErc721Contracts } from './types';
+
+export class Processor extends IEventProcessor<IErc721Contracts, RawEvent> {
+  constructor(protected _api: IErc721Contracts) {
+    super(_api);
+  }
+
+  /**
+   * Parse events out of an ethereum block and standardizes their format
+   * for processing.
+   * @param event
+   * @param tokenName
+   * @returns an array of processed events
+   */
+  public async process(
+    event: RawEvent,
+    tokenName?: string
+  ): Promise<CWEvent<IEventData>[]> {
+    const log = factory.getLogger(
+      addPrefix(__filename, [SupportedNetwork.ERC721, tokenName])
+    );
+    const kind = ParseType(event.event);
+    if (!kind) return [];
+    try {
+      const cwEvent = await Enrich(this._api, event.blockNumber, kind, event);
+      cwEvent.chain = tokenName;
+      return cwEvent ? [cwEvent] : [];
+    } catch (e) {
+      log.error(
+        `Failed to enrich event. Block number: ${event.blockNumber}, Name/Kind: ${event.event}, Error Message: ${e.message}`
+      );
+      return [];
+    }
+  }
+}

--- a/src/chains/erc721/subscribeFunc.ts
+++ b/src/chains/erc721/subscribeFunc.ts
@@ -1,0 +1,149 @@
+import sleep from 'sleep-promise';
+import _ from 'underscore';
+import BN from 'bn.js';
+
+import { createProvider } from '../../eth';
+import {
+  CWEvent,
+  SubscribeFunc,
+  ISubscribeOptions,
+  SupportedNetwork,
+} from '../../interfaces';
+import { addPrefix, factory } from '../../logging';
+import { ERC721__factory as ERC721Factory, ERC721 } from '../../contractTypes';
+
+import { Subscriber } from './subscriber';
+import { Processor } from './processor';
+import { IEventData, RawEvent, IErc721Contracts } from './types';
+
+export interface IErc721SubscribeOptions
+  extends ISubscribeOptions<IErc721Contracts> {
+  enricherConfig?;
+}
+
+/**
+ * Attempts to open an API connection, retrying if it cannot be opened.
+ * @param ethNetworkUrl
+ * @param tokenAddresses
+ * @param tokenNames
+ * @param retryTimeMs
+ * @returns a promise resolving to an ApiPromise once the connection has been established
+
+ */
+export async function createApi(
+  ethNetworkUrl: string,
+  tokenAddresses: string[],
+  tokenNames?: string[],
+  retryTimeMs = 10 * 1000
+): Promise<IErc721Contracts> {
+  const log = factory.getLogger(
+    addPrefix(__filename, [SupportedNetwork.ERC721])
+  );
+
+  for (let i = 0; i < 3; ++i) {
+    try {
+      const provider = await createProvider(
+        ethNetworkUrl,
+        SupportedNetwork.ERC721
+      );
+      log.info(`Connection to ${ethNetworkUrl} successful!`);
+
+      const tokenContracts = tokenAddresses.map((o) =>
+        ERC721Factory.connect(o, provider)
+      );
+      const deployResults: IErc721Contracts = { provider, tokens: [] };
+      for (const [contract, tokenName] of _.zip(tokenContracts, tokenNames) as [
+        ERC721,
+        string | undefined
+      ][]) {
+        try {
+          await contract.deployed();
+          const totalSupply = new BN((await contract.totalSupply()).toString());
+          deployResults.tokens.push({
+            contract,
+            totalSupply,
+            tokenName,
+          });
+        } catch (err) {
+          log.error(
+            `Error loading token ${contract.address} (${tokenName}): ${err.message}`
+          );
+        }
+      }
+      return deployResults;
+    } catch (err) {
+      log.error(`Erc20 at ${ethNetworkUrl} failure: ${err.message}`);
+      await sleep(retryTimeMs);
+      log.error('Retrying connection...');
+    }
+  }
+
+  throw new Error(
+    `[${SupportedNetwork.ERC721}]: Failed to start the ERC721 listener for ${tokenAddresses} at ${ethNetworkUrl}`
+  );
+}
+
+/**
+ * This is the main function for edgeware event handling. It constructs a connection
+ * to the chain, connects all event-related modules, and initializes event handling.
+ * @param options
+ * @returns An active block subscriber.
+ */
+export const subscribeEvents: SubscribeFunc<
+  IErc721Contracts,
+  RawEvent,
+  IErc721SubscribeOptions
+> = async (options) => {
+  const { chain, api, handlers, verbose } = options;
+  const log = factory.getLogger(
+    addPrefix(__filename, [SupportedNetwork.ERC721])
+  );
+  // helper function that sends an event through event handlers
+  const handleEventFn = async (
+    event: CWEvent<IEventData>,
+    tokenName?: string
+  ): Promise<void> => {
+    event.chain = (tokenName as never) || chain;
+    event.received = Date.now();
+    let prevResult = null;
+    for (const handler of handlers) {
+      try {
+        // pass result of last handler into next one (chaining db events)
+        prevResult = await handler.handle(event, prevResult);
+      } catch (err) {
+        log.error(`Event handle failure: ${err.message}`);
+        break;
+      }
+    }
+  };
+
+  // helper function that sends a block through the event processor and
+  // into the event handlers
+  const processor = new Processor(api);
+  const processEventFn = async (
+    event: RawEvent,
+    tokenName?: string
+  ): Promise<void> => {
+    // retrieve events from block
+    const cwEvents: CWEvent<IEventData>[] = await processor.process(event);
+
+    // process events in sequence
+    for (const cwEvent of cwEvents) {
+      await handleEventFn(cwEvent, tokenName);
+    }
+  };
+
+  const subscriber = new Subscriber(api, chain, verbose);
+
+  // helper function that runs after we've been offline/the server's been down,
+  // and attempts to fetch skipped events
+
+  try {
+    log.info(`Subscribing to ERC721 contracts ${chain}...`);
+    await subscriber.subscribe(processEventFn);
+  } catch (e) {
+    log.error(`Subscription error: ${e.message}`);
+  }
+
+  return subscriber;
+};

--- a/src/chains/erc721/subscribeFunc.ts
+++ b/src/chains/erc721/subscribeFunc.ts
@@ -1,6 +1,5 @@
 import sleep from 'sleep-promise';
 import _ from 'underscore';
-import BN from 'bn.js';
 
 import { createProvider } from '../../eth';
 import {
@@ -58,10 +57,8 @@ export async function createApi(
       ][]) {
         try {
           await contract.deployed();
-          const totalSupply = new BN((await contract.totalSupply()).toString());
           deployResults.tokens.push({
             contract,
-            totalSupply,
             tokenName,
           });
         } catch (err) {
@@ -72,7 +69,7 @@ export async function createApi(
       }
       return deployResults;
     } catch (err) {
-      log.error(`Erc20 at ${ethNetworkUrl} failure: ${err.message}`);
+      log.error(`Erc721 at ${ethNetworkUrl} failure: ${err.message}`);
       await sleep(retryTimeMs);
       log.error('Retrying connection...');
     }

--- a/src/chains/erc721/subscriber.ts
+++ b/src/chains/erc721/subscriber.ts
@@ -1,0 +1,85 @@
+/**
+ * Fetches events from Compound contract in real time.
+ */
+import { Listener } from '@ethersproject/providers';
+import sleep from 'sleep-promise';
+import BN from 'bn.js';
+
+import { IEventSubscriber, SupportedNetwork } from '../../interfaces';
+import { ERC721__factory as ERC721Factory } from '../../contractTypes';
+import { addPrefix, factory } from '../../logging';
+
+import { RawEvent, IErc721Contracts } from './types';
+
+export class Subscriber extends IEventSubscriber<IErc721Contracts, RawEvent> {
+  private _name: string;
+
+  private _listener: Listener | null;
+
+  constructor(api: IErc721Contracts, name: string, verbose = false) {
+    super(api, verbose);
+    this._name = name;
+  }
+
+  /**
+   * Initializes subscription to chain and starts emitting events.
+   */
+  public async subscribe(
+    cb: (event: RawEvent, tokenName?: string) => void
+  ): Promise<void> {
+    this._listener = (tokenName: string, event: RawEvent): void => {
+      const log = factory.getLogger(
+        addPrefix(__filename, [SupportedNetwork.ERC721, tokenName])
+      );
+      const logStr = `Received ${this._name} event: ${JSON.stringify(
+        event,
+        null,
+        2
+      )}.`;
+      // eslint-disable-next-line no-unused-expressions
+      this._verbose ? log.info(logStr) : log.trace(logStr);
+      cb(event, tokenName);
+    };
+    this._api.tokens.forEach(({ contract, tokenName }) =>
+      contract.on('*', this._listener.bind(this, tokenName))
+    );
+  }
+
+  public unsubscribe(): void {
+    if (this._listener) {
+      this._api.tokens.forEach(({ contract }) => contract.removeAllListeners());
+      this._listener = null;
+    }
+  }
+
+  public async addNewToken(
+    tokenAddress: string,
+    tokenName?: string,
+    retryTimeMs = 10 * 1000,
+    retries = 5
+  ): Promise<void> {
+    const log = factory.getLogger(
+      addPrefix(__filename, [SupportedNetwork.ERC721, tokenName])
+    );
+    const existingToken = this.api.tokens.find(({ contract }) => {
+      return contract.address === tokenAddress;
+    });
+    if (existingToken) {
+      log.info('Token is already being monitored');
+      return;
+    }
+    try {
+      const contract = ERC721Factory.connect(tokenAddress, this.api.provider);
+      await contract.deployed();
+      const totalSupply = new BN((await contract.totalSupply()).toString());
+      this.api.tokens.push({ contract, totalSupply, tokenName });
+      contract.on('*', this._listener.bind(this, tokenName));
+    } catch (e) {
+      await sleep(retryTimeMs);
+      if (retries > 0) {
+        log.error('Retrying connection...');
+        this.addNewToken(tokenAddress, tokenName, retryTimeMs, retries - 1);
+      }
+    }
+  }
+}

--- a/src/chains/erc721/subscriber.ts
+++ b/src/chains/erc721/subscriber.ts
@@ -1,9 +1,8 @@
 /**
- * Fetches events from Compound contract in real time.
+ * Fetches events from ERC721 contract in real time.
  */
 import { Listener } from '@ethersproject/providers';
 import sleep from 'sleep-promise';
-import BN from 'bn.js';
 
 import { IEventSubscriber, SupportedNetwork } from '../../interfaces';
 import { ERC721__factory as ERC721Factory } from '../../contractTypes';
@@ -71,8 +70,7 @@ export class Subscriber extends IEventSubscriber<IErc721Contracts, RawEvent> {
     try {
       const contract = ERC721Factory.connect(tokenAddress, this.api.provider);
       await contract.deployed();
-      const totalSupply = new BN((await contract.totalSupply()).toString());
-      this.api.tokens.push({ contract, totalSupply, tokenName });
+      this.api.tokens.push({ contract, tokenName });
       contract.on('*', this._listener.bind(this, tokenName));
     } catch (e) {
       await sleep(retryTimeMs);

--- a/src/chains/erc721/types.ts
+++ b/src/chains/erc721/types.ts
@@ -1,0 +1,69 @@
+import { Web3Provider } from '@ethersproject/providers';
+import BN from 'bn.js';
+
+import { TypedEvent } from '../../contractTypes/commons';
+import { ERC721 } from '../../contractTypes';
+
+interface IErc721Contract {
+  contract: ERC721;
+  totalSupply: BN;
+  tokenName?: string;
+}
+
+export interface IErc721Contracts {
+  tokens: IErc721Contract[];
+  provider: Web3Provider;
+}
+
+export interface ListenerOptions {
+  url: string;
+  tokenAddresses: string[];
+  tokenNames?: string[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RawEvent = TypedEvent<any>;
+
+// eslint-disable-next-line no-shadow
+export enum EventKind {
+  // Erc721 Events
+  Approval = 'approval',
+  ApprovalForAll = 'approval for all',
+  Transfer = 'transfer',
+}
+
+interface IEvent {
+  kind: EventKind;
+}
+
+type Address = string;
+type TokenID = string;
+
+// Erc721 Event Interfaces
+export interface IApproval extends IEvent {
+  kind: EventKind.Approval;
+  owner: Address;
+  approved: Address;
+  tokenId: TokenID;
+  contractAddress: Address;
+}
+
+export interface IApprovalForAll extends IEvent {
+  kind: EventKind.ApprovalForAll;
+  owner: Address;
+  operator: Address;
+  approved: boolean;
+  contractAddress: Address;
+}
+
+export interface ITransfer extends IEvent {
+  kind: EventKind.Transfer;
+  from: Address;
+  to: Address;
+  tokenId: TokenID;
+  contractAddress: Address;
+}
+
+export type IEventData = IApproval | IApprovalForAll | ITransfer;
+
+export const EventKinds: EventKind[] = Object.values(EventKind);

--- a/src/chains/erc721/types.ts
+++ b/src/chains/erc721/types.ts
@@ -1,12 +1,10 @@
 import { Web3Provider } from '@ethersproject/providers';
-import BN from 'bn.js';
 
 import { TypedEvent } from '../../contractTypes/commons';
 import { ERC721 } from '../../contractTypes';
 
 interface IErc721Contract {
   contract: ERC721;
-  totalSupply: BN;
   tokenName?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ export * as SubstrateEvents from './chains/substrate/index';
 export * as SubstrateTypes from './chains/substrate/types';
 export * as Erc20Events from './chains/erc20/index';
 export * as Erc20Types from './chains/erc20/types';
+export * as Erc721Events from './chains/erc721/index';
+export * as Erc721Types from './chains/erc721/types';
 export * as AaveEvents from './chains/aave/index';
 export * as AaveTypes from './chains/aave/types';
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,6 +6,7 @@ import * as SubstrateTypes from './chains/substrate/types';
 import * as MolochTypes from './chains/moloch/types';
 import * as CompoundTypes from './chains/compound/types';
 import * as Erc20Types from './chains/erc20/types';
+import * as Erc721Types from './chains/erc721/types';
 import * as AaveTypes from './chains/aave/types';
 
 // add other events here as union types
@@ -19,19 +20,22 @@ export type IChainEventData =
   | MolochTypes.IEventData
   | CompoundTypes.IEventData
   | AaveTypes.IEventData
-  | Erc20Types.IEventData;
+  | Erc20Types.IEventData
+  | Erc721Types.IEventData;
 export type IChainEventKind =
   | SubstrateTypes.EventKind
   | MolochTypes.EventKind
   | CompoundTypes.EventKind
   | AaveTypes.EventKind
-  | Erc20Types.EventKind;
+  | Erc20Types.EventKind
+  | Erc721Types.EventKind;
 export const ChainEventKinds = [
   ...SubstrateTypes.EventKinds,
   ...MolochTypes.EventKinds,
   ...CompoundTypes.EventKinds,
   ...AaveTypes.EventKinds,
   ...Erc20Types.EventKinds,
+  ...Erc721Types.EventKinds,
 ];
 
 // eslint-disable-next-line no-shadow
@@ -41,6 +45,7 @@ export enum SupportedNetwork {
   Compound = 'compound',
   Moloch = 'moloch',
   ERC20 = 'erc20',
+  ERC721 = 'erc721',
 }
 
 // eslint-disable-next-line no-shadow

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,6 +30,11 @@ import {
   Label as Erc20Label,
 } from './chains/erc20';
 import {
+  Listener as Erc721Listener,
+  Title as Erc721Title,
+  Label as Erc721Label,
+} from './chains/erc721';
+import {
   Listener as AaveListener,
   Title as AaveTitle,
   Label as AaveLabel,
@@ -50,6 +55,8 @@ export function Title(
       return CompoundTitle(kind);
     case SupportedNetwork.ERC20:
       return Erc20Title(kind);
+    case SupportedNetwork.ERC721:
+      return Erc721Title(kind);
     case SupportedNetwork.Moloch:
       return MolochTitle(kind);
     default:
@@ -67,6 +74,8 @@ export function Label(chain: string, event: CWEvent): IEventLabel {
       return CompoundLabel(event.blockNumber, chain, event.data);
     case SupportedNetwork.ERC20:
       return Erc20Label(event.blockNumber, chain, event.data);
+    case SupportedNetwork.ERC721:
+      return Erc721Label(event.blockNumber, chain, event.data);
     case SupportedNetwork.Moloch:
       return MolochLabel(event.blockNumber, chain, event.data);
     default:
@@ -154,6 +163,14 @@ export async function createListener(
       options.url,
       Array.isArray(options.tokenNames) ? options.tokenNames : undefined,
       options.enricherConfig,
+      !!options.verbose
+    );
+  } else if (network === SupportedNetwork.ERC721) {
+    listener = new Erc721Listener(
+      chain,
+      options.tokenAddresses || [options.address],
+      options.url,
+      Array.isArray(options.tokenNames) ? options.tokenNames : undefined,
       !!options.verbose
     );
   } else if (network === SupportedNetwork.Aave) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added listening/processing of emitted ERC721 events.

## Description
<!--- Describe your changes in detail -->
New ERC721 module added under _chains_ which is very similar to the ERC20 module, but with some minor modifications to support the different set of events emitted by ERC721.

In particular:

- Event interfaces are different (additional _ApprovalForAll_ event), with different fields for event data.
- _EnricherConfig_ and the accompanying transfer threshold size has been removed (at least for now), given that NFTs are sent on a token-by-token basis and as such there are no "whale" transactions to pay attention to.
- Modified event titling and labeling to be consistent with ERC721-emitted events.

## Motivation and Context
Allows support for ERC721 event notifications.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Testing ongoing.

## Have proper tags been added (for bug, enhancement, breaking change)?
Yes.
